### PR TITLE
Results refactor part 3: Spread max results evenly among multiple providers

### DIFF
--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -650,7 +650,7 @@ class Autocompleter(AutocompleterBase):
         # Get an initial max/provider based on a equal share of MAX_RESULTS
         for provider in providers:
             provider_name = provider.provider_name
-            results_per_provider = round(MAX_RESULTS / len(providers))
+            results_per_provider = self.normalize_rounding(MAX_RESULTS / len(providers))
             provider_max_results[provider_name] = results_per_provider
             total_allocated_results += results_per_provider
 
@@ -853,3 +853,16 @@ class Autocompleter(AutocompleterBase):
         facet_hashes.sort()
         final_facet_hash = hash(str(facet_hashes))
         return final_facet_hash
+
+    @staticmethod
+    def normalize_rounding(value):
+        """
+        Python 2 and Python 3 handing the rounding of halves (0.5, 1.5, etc) differently.
+        Stick to Python 2 version of rounding to be consistent.
+        """
+        if not isinstance(value, (int, float)):
+            raise ValueError("Value to round must be an int or float, not %s." % type(value).__name__)
+        if round(0.5) != 1 and value % 1 == .5 and not int(value) % 2:
+            return int((round(value) + (abs(value) / value) * 1))
+        else:
+            return int(round(value))

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -284,6 +284,7 @@ class MaxResultsMatchingTestCase(AutocompleterTestCase):
         matches = self.autocomp.suggest('a')
         total_matches_with_large_max_results = len(matches['stock']) + len(matches['ind'])
         self.assertGreaterEqual(100, total_matches_with_large_max_results)
+        self.assertEqual(41, total_matches_with_large_max_results)
 
         registry.set_autocompleter_setting('ind_stock', 'MAX_RESULTS', 4)
         matches = self.autocomp.suggest('a')

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -231,16 +231,16 @@ class MultiMatchingTestCase(AutocompleterTestCase):
         self.assertEqual(len(matches), 3)
 
         matches = self.autocomp.suggest('a')
-        self.assertEqual(len(matches['stock']), 10)
-        self.assertEqual(len(matches['ind']), 10)
+        self.assertEqual(len(matches['stock']), 6)
+        self.assertEqual(len(matches['ind']), 4)
 
     def test_min_letters_setting(self):
         """
         MIN_LETTERS is respected in multi-type search case.
         """
         matches = self.autocomp.suggest('a')
-        self.assertEqual(len(matches['stock']), 10)
-        self.assertEqual(len(matches['ind']), 10)
+        self.assertEqual(len(matches['stock']), 6)
+        self.assertEqual(len(matches['ind']), 4)
 
         setattr(auto_settings, 'MIN_LETTERS', 2)
         matches = self.autocomp.suggest('a')
@@ -253,8 +253,8 @@ class MultiMatchingTestCase(AutocompleterTestCase):
         Autocompleter/Provider specific MIN_LETTERS is respected in multi-type search case.
         """
         matches = self.autocomp.suggest('a')
-        self.assertEqual(len(matches['stock']), 10)
-        self.assertEqual(len(matches['ind']), 10)
+        self.assertEqual(len(matches['stock']), 6)
+        self.assertEqual(len(matches['ind']), 4)
 
         registry.set_ac_provider_setting("mixed", IndicatorAutocompleteProvider, 'MIN_LETTERS', 2)
         registry.set_ac_provider_setting("mixed", CalcAutocompleteProvider, 'MIN_LETTERS', 2)
@@ -264,6 +264,58 @@ class MultiMatchingTestCase(AutocompleterTestCase):
 
         registry.del_ac_provider_setting("mixed", IndicatorAutocompleteProvider, 'MIN_LETTERS')
         registry.del_ac_provider_setting("mixed", CalcAutocompleteProvider, 'MIN_LETTERS')
+
+
+class MaxResultsMatchingTestCase(AutocompleterTestCase):
+    fixtures = ['stock_test_data_small.json', 'indicator_test_data_small.json']
+
+    def setUp(self):
+        super(MaxResultsMatchingTestCase, self).setUp()
+        self.autocomp = Autocompleter('ind_stock')
+        self.autocomp.store_all()
+
+    def test_max_results_respected(self):
+        """
+        MAX_RESULTS is respected for multi-type search case
+        """
+        # set MAX_RESULTS to an arbitrarily large number
+        registry.set_autocompleter_setting('ind_stock', 'MAX_RESULTS', 100)
+
+        matches = self.autocomp.suggest('a')
+        total_matches_with_large_max_results = len(matches['stock']) + len(matches['ind'])
+        self.assertGreaterEqual(100, total_matches_with_large_max_results)
+
+        registry.set_autocompleter_setting('ind_stock', 'MAX_RESULTS', 4)
+        matches = self.autocomp.suggest('a')
+        total_matches_with_small_max_results = len(matches['stock']) + len(matches['ind'])
+        self.assertEqual(4, total_matches_with_small_max_results)
+
+        self.assertGreater(total_matches_with_large_max_results, total_matches_with_small_max_results)
+
+        registry.del_autocompleter_setting('ind_stock', 'MAX_RESULTS')
+
+    def test_max_results_spreads_results_evenly(self):
+        """
+        MAX_RESULTS spreads the results among providers equally
+        """
+        registry.set_autocompleter_setting('ind_stock', 'MAX_RESULTS', 4)
+        matches = self.autocomp.suggest('a')
+        self.assertEqual(4, len(matches['stock']) + len(matches['ind']))
+        self.assertEqual(len(matches['stock']), len(matches['ind']))
+
+        registry.del_autocompleter_setting('ind_stock', 'MAX_RESULTS')
+
+    def test_max_results_handles_surplus(self):
+        """
+        Suggest respects MAX_RESULTS while still dealing with surplus
+        """
+        # we know that there are 16 ind matches and 25 stock matches for 'a'
+        registry.set_autocompleter_setting('ind_stock', 'MAX_RESULTS', 36)
+        matches = self.autocomp.suggest('a')
+        self.assertEqual(16, len(matches['ind']))
+        self.assertEqual(20, len(matches['stock']))
+
+        registry.del_autocompleter_setting('ind_stock', 'MAX_RESULTS')
 
 
 class FacetMatchingTestCase(AutocompleterTestCase):

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -317,6 +317,17 @@ class MaxResultsMatchingTestCase(AutocompleterTestCase):
 
         registry.del_autocompleter_setting('ind_stock', 'MAX_RESULTS')
 
+    def test_max_results_has_hard_limit(self):
+        """
+        Suggest respects MAX_RESULTS over giving every provider at least 1 result
+        """
+        registry.set_autocompleter_setting('ind_stock', 'MAX_RESULTS', 1)
+        matches = self.autocomp.suggest('a')
+        # Either stock or indicator matches is empty
+        self.assertEqual(1, len(matches['stock']) + len(matches['ind']))
+
+        registry.del_autocompleter_setting('ind_stock', 'MAX_RESULTS')
+
 
 class FacetMatchingTestCase(AutocompleterTestCase):
     fixtures = ['stock_test_data_small.json']

--- a/test_project/test_app/tests/test_utils.py
+++ b/test_project/test_app/tests/test_utils.py
@@ -233,3 +233,23 @@ class TestFacetValidation(TestCase):
         ]
 
         self.assertFalse(SuggestView.validate_facets(no_value_in_sub_facet))
+
+
+class TestNormalizeRounding(TestCase):
+    def test_rounding_half(self):
+        """
+        Rounding a number that ends in .5 should produce a number with a greater absolute value
+        """
+        self.assertEqual(1, Autocompleter.normalize_rounding(.5))
+        self.assertEqual(2, Autocompleter.normalize_rounding(1.5))
+        self.assertEqual(-1, Autocompleter.normalize_rounding(-.5))
+        self.assertEqual(-2, Autocompleter.normalize_rounding(-1.5))
+
+    def test_rounding_works_correctly(self):
+        """
+        Rounding works correctly
+        """
+        self.assertEqual(1, Autocompleter.normalize_rounding(.51))
+        self.assertEqual(0, Autocompleter.normalize_rounding(.49))
+        self.assertEqual(-1, Autocompleter.normalize_rounding(-.51))
+        self.assertEqual(0, Autocompleter.normalize_rounding(-.49))


### PR DESCRIPTION
## pivotal
https://www.pivotaltracker.com/story/show/158440178

## background
An autocompleter now does not return more than the max results setting, spreading results evenly among multiple providers.