### PR TITLE
Bug fix total surplus inf loop

### DIFF
--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 0)
+VERSION = (0, 7, 1)
 
 from autocompleter.registry import registry, signal_registry
 from autocompleter.base import AutocompleterBase, AutocompleterModelProvider, AutocompleterDictProvider, Autocompleter

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -721,8 +721,8 @@ class Autocompleter(AutocompleterBase):
         # If there are extra result slots available, go through each provider that
         # needs extra results, and hand them out until there are no more to give
         while total_surplus > 0:
-            # Check if there are any existing providers which need a handout, otherwise
-            # we get caught in an infinite loop
+            # Check if there are any providers that still need extra results, and if not exit the loop,
+            # else we get caught in an infinite loop
             provider_with_deficit_exists = False
             for provider_name in provider_deficits:
                 deficit = provider_deficits[provider_name]

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -721,9 +721,14 @@ class Autocompleter(AutocompleterBase):
         # If there are extra result slots available, go through each provider that
         # needs extra results, and hand them out until there are no more to give
         while total_surplus > 0:
-            # Can happen if no provider has a deficit and the total number of results
-            # from all providers < MAX_RESULTS
-            if len(provider_deficits) == 0:
+            # Check if there are any existing providers which need a handout, otherwise
+            # we get caught in an infinite loop
+            provider_with_deficit_exists = False
+            for provider_name in provider_deficits:
+                deficit = provider_deficits[provider_name]
+                if deficit > 0:
+                    provider_with_deficit_exists = True
+            if not provider_with_deficit_exists:
                 break
             for provider_name in provider_deficits:
                 deficit = provider_deficits[provider_name]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-autocompleter',
-    version="0.7.0",
+    version="0.7.1",
     description='A redis-backed autocompletor for Django projects',
     author='Ara Anjargolian',
     author_email='ara818@gmail.com',

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -318,6 +318,23 @@ class MaxResultsMatchingTestCase(AutocompleterTestCase):
 
         registry.del_autocompleter_setting('ind_stock', 'MAX_RESULTS')
 
+    def test_max_results_handles_deficit_less_than_surplus(self):
+        """
+        MAX_RESULTS stops trying to hand out surplus matches when provider's deficits are met
+        """
+        # Previous code would have failed on this test case because of an infinite while loop that
+        # failed to break when all provider's deficits were met. The setup requires
+        # there to be at least one provider which will have a deficit less than the total surplus.
+        # In this test case, the total surplus will be 3 (since stock has no matches) and the deficit
+        # for indicators will be 2 (since there are 5 total matches for indicators and 3 slots are
+        # reserved initially)
+        registry.set_autocompleter_setting('ind_stock', 'MAX_RESULTS', 6)
+        matches = self.autocomp.suggest('S&P')
+        self.assertEqual(5, len(matches['ind']))
+        self.assertEqual(0, len(matches['stock']))
+
+        registry.del_autocompleter_setting('ind_stock', 'MAX_RESULTS')
+
     def test_max_results_has_hard_limit(self):
         """
         Suggest respects MAX_RESULTS over giving every provider at least 1 result


### PR DESCRIPTION
Previously when making a suggest call, if the total deficit of providers < total surplus when handing out surplus matches, there would be an infinite loop since there was no check that the providers deficits had been met.

To test, you can undo the changes to autocompleter/base.py and run the supplied test case. It will run indefinitely until you explicitly cancel it since it will be in an infinite loop.