### PR TITLE
Bug fix result sets

### DIFF
--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 1)
+VERSION = (0, 7, 2)
 
 from autocompleter.registry import registry, signal_registry
 from autocompleter.base import AutocompleterBase, AutocompleterModelProvider, AutocompleterDictProvider, Autocompleter

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -538,6 +538,8 @@ class Autocompleter(AutocompleterBase):
 
         # Generate a unique identifier to be used for storing intermediate results. This is to
         # prevent redis key collisions between competing suggest / exact_suggest calls.
+        base_term_result_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+        base_result_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
 
         facet_keys_set = set()
         if len(facets) > 0:
@@ -553,12 +555,6 @@ class Autocompleter(AutocompleterBase):
         MAX_RESULTS = registry.get_autocompleter_setting(self.name, 'MAX_RESULTS')
 
         for provider in providers:
-
-            base_term_result_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
-            # If we don't end up using facets for this suggest call, we can just set the base_result_key
-            # to be equal to base_term_result_key since there was no extra manipulation to this set.
-            base_result_key = base_term_result_key
-
             provider_name = provider.provider_name
 
             # If the total length of the term is less than MIN_LETTERS allowed, then don't search
@@ -574,7 +570,7 @@ class Autocompleter(AutocompleterBase):
                 term_result_keys.append(term_result_key)
                 keys = [PREFIX_BASE_NAME % (provider_name, norm_word,) for norm_word in norm_words]
                 pipe.zinterstore(term_result_key, keys, aggregate='MIN')
-            pipe.zunionstore(base_term_result_key, term_result_keys, aggregate='MIN')
+            pipe.zunionstore(base_result_key, term_result_keys, aggregate='MIN')
             for term_result_key in term_result_keys:
                 pipe.delete(term_result_key)
 
@@ -606,16 +602,19 @@ class Autocompleter(AutocompleterBase):
                     except KeyError:
                         continue
                 # We want to calculate the intersection of all the intermediate facet sets created so far
-                # along with the base term result set. So we need to use a new unique name for the
-                # intermediate result set and append the base_term_result_key to the list of
+                # along with the base result set. So we need to use a new unique name for the
+                # intermediate result set and append the base_result_key to the list of
                 # facet_result_keys.
-                base_result_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
-                facet_result_keys.append(base_term_result_key)
-                pipe.zinterstore(base_result_key, facet_result_keys, aggregate='MIN')
+                faceted_base_result_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                facet_result_keys.append(base_result_key)
+                pipe.zinterstore(faceted_base_result_key, facet_result_keys, aggregate='MIN')
                 for facet_result_key in facet_result_keys:
                     pipe.delete(facet_result_key)
 
-            pipe.zrange(base_result_key, 0, MAX_RESULTS - 1)
+            if use_facets:
+                pipe.zrange(faceted_base_result_key, 0, MAX_RESULTS - 1)
+            else:
+                pipe.zrange(base_result_key, 0, MAX_RESULTS - 1)
 
             # Get exact matches
             if MOVE_EXACT_MATCHES_TO_TOP:
@@ -631,17 +630,22 @@ class Autocompleter(AutocompleterBase):
                     # exact term matches don't bypass the requirement of having matching facet values.
                     # To achieve this, we append the previous intermediate result key (which at this point will
                     # contain all the facet matches) to the list of exact match keys and perform an intersection.
-                    keys.append(base_result_key)
-                    old_base_result_key = base_result_key
-                    base_result_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
-                    pipe.zinterstore(base_result_key, keys, aggregate='MIN')
-                    pipe.delete(old_base_result_key)
+                    facet_exact_match_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                    keys.append(faceted_base_result_key)
+                    pipe.zinterstore(facet_exact_match_key, keys, aggregate='MIN')
                 else:
                     pipe.zunionstore(base_result_key, keys, aggregate='MIN')
-                pipe.zrange(base_result_key, 0, MAX_RESULTS - 1)
+
+                if use_facets:
+                    pipe.zrange(facet_exact_match_key, 0, MAX_RESULTS - 1)
+                    pipe.delete(facet_exact_match_key)
+                else:
+                    pipe.zrange(base_result_key, 0, MAX_RESULTS - 1)
+
             pipe.delete(base_term_result_key)
-            if base_term_result_key != base_result_key:
-                pipe.delete(base_result_key)
+            pipe.delete(base_result_key)
+            if use_facets:
+                pipe.delete(faceted_base_result_key)
 
         results = [i for i in pipe.execute() if type(i) == list]
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-autocompleter',
-    version="0.7.1",
+    version="0.7.2",
     description='A redis-backed autocompletor for Django projects',
     author='Ara Anjargolian',
     author_email='ara818@gmail.com',

--- a/test_project/test_app/autocompleters.py
+++ b/test_project/test_app/autocompleters.py
@@ -224,3 +224,6 @@ registry.register("indicator_aliased", IndicatorAliasedAutocompleteProvider)
 registry.register("indicator_selective", IndicatorSelectiveAutocompleteProvider)
 registry.register("metric", CalcAutocompleteProvider)
 registry.register("metric_aliased", CalcAliasedAutocompleteProvider)
+
+registry.register("facet_stock_no_facet_ind", FacetedStockAutocompleteProvider)
+registry.register("facet_stock_no_facet_ind", IndicatorAutocompleteProvider)


### PR DESCRIPTION
### Overview
If a provider uses facets, it ends up setting a new base result key, which will make it seem like any subsequent provider has no results. Instead of trying to use the base result key for facet suggest, create a new faceted_base_result_key and facet_exact_match_key to prevent overwriting key names.

### Test
- python test_app.tests.test_matching.MixedFacetProvidersMatchingTestCase
- the above test should fail when using the old base.py code
