### PR TITLE
Part 2: adds AutocompleterSelectWidget

### DIFF
--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -817,6 +817,20 @@ class Autocompleter(AutocompleterBase):
             REDIS.setex(cache_key, self.__class__._serialize_data(results), settings.CACHE_TIMEOUT)
         return results
 
+    def get_provider_result_from_id(self, provider_name, object_id):
+        """
+        Given an object's `search_id`, return the corresponding data object.
+        """
+        results = self._get_results_from_ids({provider_name: [object_id]})
+        try:
+            if isinstance(results, list):
+                result = results[0]
+            else:
+                result = list(filter(None, results.values()))[0][0]
+        except IndexError:
+            result = {}
+        return result
+
     def _get_results_from_ids(self, provider_results):
         """
         Given a dict mapping providers to results IDs, return

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -819,7 +819,7 @@ class Autocompleter(AutocompleterBase):
 
     def get_provider_result_from_id(self, provider_name, object_id):
         """
-        Given an object's `search_id`, return the corresponding data object.
+        Given a `provider_name` and `id`, return the corresponding redis payload.
         """
         results = self._get_results_from_ids({provider_name: [object_id]})
         try:

--- a/autocompleter/widgets.py
+++ b/autocompleter/widgets.py
@@ -50,8 +50,9 @@ class AutocompleterSelectWidgetBase(forms.MultiWidget):
         2. `HiddenInput`: renders an <input> that holds the actual DB value (which is some kind of GUI)
 
     :autocompleter_name - `str` the Autocompleter used for search.
-    :display_name_field - `str` obj field to display to user when result is selected.
-    :database_field     - `str` obj field to save to the DB.
+    :autocompleter_url  - `str` the search URL for the autocompleter API.
+    :display_name_field - `str` field from payload to display to user when result is selected.
+    :database_field     - `str` field from payload to save to the DB, serving as the obj identifier.
     """
     def __init__(self, autocompleter_name, autocompleter_url, display_name_field,
                  database_field, *args, **kwargs):

--- a/autocompleter/widgets.py
+++ b/autocompleter/widgets.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from django import forms
 from django.conf import settings
 from django.db.models import ObjectDoesNotExist
@@ -45,7 +43,13 @@ class AutocompleterSelectWidget(forms.MultiWidget):
 
     Wrapper for 2 widgets:
         1. `AutocompleterWidget`: renders an <input> that acts as the search field.
-        2. `HiddenInput`: renders an <input> that holds the actual object ID / `search_id` value.
+        2. `HiddenInput`: renders an <input> that holds the actual DB value (which is some kind of GUI)
+
+
+    :autocompleter_name - `str` specify the Autocompleter to use for search.
+    :display_name_field - `str` specify field from payload to display to user when result is selected.
+    :database_field     - `str` specify field from payload to save to the DB (should be a GUI).
+    :object_resolver    - `callable` that can fetch the object using the `database_field` value.
     """
 
     def __init__(self, autocompleter_name, autocompleter_url, display_name_field,
@@ -99,8 +103,10 @@ class AutocompleterSelectWidget(forms.MultiWidget):
 
     def _get_model_provider(self, obj):
         """
-        Fetch the `ModelProvider` class from the registry. Because there is no guarantee that it
-        is unique per AC or per object_class, we take the intersection of both result sets.
+        Fetch the `AutocompleterModelProvider` class for a specific model from the registry.
+
+        Note: because there is no guarantee that a provider is unique per Autocompleter
+        or per model_class alone, we take the intersection of both result sets.
         """
         providers_by_ac = set(registry.get_all_by_autocompleter(self.autocompleter_name))
         model_providers = set(registry.get_all_by_model(obj.__class__))


### PR DESCRIPTION
[Pivotal Tracker Ticket](https://www.pivotaltracker.com/story/show/159322274)

### Overview
- adds the `AutocompleterSelectWidgetBase`
    - MultiWidget child class that handles rendering of 2 `<input>` elements:
            1.  the `AutocompleterWidget`, effectively acting as the search field, interacting via jQuery with the AC API
            2. a `HiddenInput`, acting as the `<input>` that holds the actual object identifier
    - implements the `decompress` method, which maps the object identifier value (e.g. `AAPL`) stored in the DB to both widgets, e.g. `['Apple Inc.', 'AAPL']`
    - because this is a base class, extends 2 hooks, `_get_provider` and `_get_object_id` that the child can implement to be useable.

- adds the `AutocompleterDictProviderSelectWidget`, which implements those two methods.
