### PR TITLE
Part 3: adds AutocompleterSelectField

### DIFF
--- a/autocompleter/fields.py
+++ b/autocompleter/fields.py
@@ -1,0 +1,40 @@
+from django import forms
+from autocompleter.widgets import AutocompleterDictProviderSelectWidget
+
+
+class AutocompleterDictProviderSelectField(forms.CharField):
+    """
+    Django forms.CharField that implements the `AutocompleterSelectWidget`.
+    """
+    widget = AutocompleterDictProviderSelectWidget
+
+    default_error_messages = {
+        'invalid_choice': 'Select a valid choice. That choice is not one of the available choices.',
+    }
+
+    def __init__(self, autocompleter_name, autocompleter_url, display_name_field,
+                 database_field, *args, **kwargs):
+        kwargs['widget'] = self.widget(
+            autocompleter_name, autocompleter_url, display_name_field, database_field,
+        )
+        super().__init__(*args, **kwargs)
+
+    def to_python(self, value):
+        """
+        Essentially the reverse of `decompress` on the `AutocompleterSelectWidget`,
+        i.e. `value` is a list of values, each corresponding to a widget, and we pick out
+        the one we want to commit to the DB.
+        In this case, the object identifier is from the HiddenInput, which is the 2nd value.
+        """
+        if not value:
+            return None
+
+        if not isinstance(value, list):
+            data_field_value = value
+        else:
+            if len(value) != 2:
+                raise forms.ValidationError(self.error_messages['invalid_choice'])
+            else:
+                data_field_value = value[1]
+
+        return data_field_value

--- a/autocompleter/fields.py
+++ b/autocompleter/fields.py
@@ -17,7 +17,7 @@ class AutocompleterDictProviderSelectField(forms.CharField):
         kwargs['widget'] = self.widget(
             autocompleter_name, autocompleter_url, display_name_field, database_field,
         )
-        super().__init__(*args, **kwargs)
+        super(AutocompleterDictProviderSelectField, self).__init__(*args, **kwargs)
 
     def to_python(self, value):
         """

--- a/autocompleter/widgets.py
+++ b/autocompleter/widgets.py
@@ -21,7 +21,7 @@ class AutocompleterWidget(forms.TextInput):
         }
 
     def __init__(self, autocompleter_url, display_name_field, database_field, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(AutocompleterWidget, self).__init__(*args, **kwargs)
         self.autocompleter_url = autocompleter_url
         self.display_name_field = display_name_field
         self.database_field = database_field
@@ -30,7 +30,7 @@ class AutocompleterWidget(forms.TextInput):
         """
         pass autocompleter values to jQuery via data-attributes
         """
-        attrs = super().build_attrs(*args, **kwargs)
+        attrs = super(AutocompleterWidget, self).build_attrs(*args, **kwargs)
         attrs.update({
             'data-autocompleter': '',
             'data-autocompleter-url': self.autocompleter_url,
@@ -64,7 +64,7 @@ class AutocompleterSelectWidgetBase(forms.MultiWidget):
             AutocompleterWidget(autocompleter_url, display_name_field, database_field),
             forms.HiddenInput()
         ]
-        super().__init__(widgets, *args, **kwargs)
+        super(AutocompleterSelectWidgetBase, self).__init__(widgets, *args, **kwargs)
 
     def decompress(self, value):
         """

--- a/test_project/test_app/admin.py
+++ b/test_project/test_app/admin.py
@@ -1,0 +1,19 @@
+from django.contrib import admin
+from test_app.models import Stock, Indicator, CalcList, CalcListItem
+from test_app.forms import CalcListItemForm
+
+
+class CalcListItemInline(admin.TabularInline):
+    model = CalcListItem
+    fk_name = 'calc_list'
+    form = CalcListItemForm
+
+
+class CalcListAdmin(admin.ModelAdmin):
+    model = CalcList
+    inlines = [CalcListItemInline]
+
+
+admin.site.register(Stock)
+admin.site.register(Indicator)
+admin.site.register(CalcList, CalcListAdmin)

--- a/test_project/test_app/autocompleters.py
+++ b/test_project/test_app/autocompleters.py
@@ -147,13 +147,10 @@ class IndicatorSelectiveAutocompleteProvider(AutocompleterModelProvider):
 class CalcAutocompleteProvider(AutocompleterDictProvider):
     obj_dict = calc_info.calc_dicts
     provider_name = "metric"
-
     settings = {}
 
-    obj_dict = calc_info.calc_dicts
-
     def get_item_id(self):
-        return self.obj['label']
+        return self.obj['short_label']
 
     def get_term(self):
         return self.obj['label']
@@ -164,7 +161,7 @@ class CalcAutocompleteProvider(AutocompleterDictProvider):
     def get_data(self):
         return {
             'type': 'metric',
-            'id': self.obj['label'],
+            'id': self.get_item_id(),
             'score': self.obj.get('score', 1),
             'display_name': u'%s' % (self.obj['label'],),
             'search_name': u'%s' % (self.obj['label'],),

--- a/test_project/test_app/forms.py
+++ b/test_project/test_app/forms.py
@@ -1,0 +1,18 @@
+from autocompleter.fields import AutocompleterDictProviderSelectField
+from django import forms
+from django.core.urlresolvers import reverse_lazy
+
+from test_app.models import CalcListItem
+
+
+class CalcListItemForm(forms.ModelForm):
+    calc_name = AutocompleterDictProviderSelectField(
+        autocompleter_name='metric',
+        autocompleter_url=reverse_lazy('suggest', kwargs=dict(name='metric')),
+        display_name_field='display_name',
+        database_field='id',
+    )
+
+    class Meta:
+        model = CalcListItem
+        fields = ('calc_name',)

--- a/test_project/test_app/forms.py
+++ b/test_project/test_app/forms.py
@@ -1,6 +1,12 @@
 from autocompleter.fields import AutocompleterDictProviderSelectField
 from django import forms
-from django.urls import reverse_lazy
+# compatible with django 1.7 - 2.0
+try:
+    # django >= 1.10
+    from django.urls import reverse_lazy
+except ImportError:
+    # django 1.7 - 1.9
+    from django.core.urlresolvers import reverse_lazy
 
 from test_app.models import CalcListItem
 

--- a/test_project/test_app/forms.py
+++ b/test_project/test_app/forms.py
@@ -1,6 +1,6 @@
 from autocompleter.fields import AutocompleterDictProviderSelectField
 from django import forms
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 
 from test_app.models import CalcListItem
 

--- a/test_project/test_app/models.py
+++ b/test_project/test_app/models.py
@@ -13,3 +13,12 @@ class Indicator(models.Model):
     name = models.CharField(max_length=200, unique=True)
     internal_name = models.CharField(max_length=200, unique=True)
     score = models.FloatField(null=True, blank=True)
+
+
+class CalcList(models.Model):
+    name = models.CharField(max_length=200, unique=True)
+
+
+class CalcListItem(models.Model):
+    calc_list = models.ForeignKey(CalcList)
+    calc_name = models.CharField(max_length=200)

--- a/test_project/test_app/models.py
+++ b/test_project/test_app/models.py
@@ -20,5 +20,5 @@ class CalcList(models.Model):
 
 
 class CalcListItem(models.Model):
-    calc_list = models.ForeignKey(CalcList)
+    calc_list = models.ForeignKey(CalcList, on_delete=models.CASCADE)
     calc_name = models.CharField(max_length=200)

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -17,12 +17,17 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
+    'django.contrib.staticfiles',
     'django_nose',
     'test_app',
     'autocompleter',
 ]
 
-MIDDLEWARE_CLASSES = ()
+MIDDLEWARE_CLASSES = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
 
 AUTOCOMPLETER_REDIS_CONNECTION = {
     'host': 'localhost',
@@ -32,7 +37,7 @@ AUTOCOMPLETER_REDIS_CONNECTION = {
 
 AUTOCOMPLETER_TEST_DATA = True
 
-ROOT_URLCONF = 'autocompleter.urls'
+ROOT_URLCONF = 'test_project.urls'
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
@@ -44,3 +49,8 @@ NOSE_ARGS = [
 ]
 
 SECRET_KEY = 'asdvdfbdgbrf076'
+
+DEBUG = True
+WSGI_APPLICATION = 'test_project.wsgi.application'
+
+STATIC_URL = '/static/'

--- a/test_project/test_project/urls.py
+++ b/test_project/test_project/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url, include
+from django.contrib import admin
+
+
+urlpatterns = [
+    url(r'^admin/', admin.site.urls),
+    url(r'', include('autocompleter.urls')),
+]

--- a/test_project/test_project/wsgi.py
+++ b/test_project/test_project/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for earth project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_project.settings")
+
+application = get_wsgi_application()


### PR DESCRIPTION
[Pivotal Tracker Ticket](https://www.pivotaltracker.com/story/show/159322320)

### Overview
- adds `AutocompleterSelectField`
    - `forms.CharField` that implements the `AutocompleterSelectWidget`
    - implements the `to_python` method, basically the reverse of `decompress`, namely, takes in the values from both widgets and pulls out the one we want to commit to the DB, which is the object identifier (2nd value)
- adds `admin` panel for `test_project` (requires some more settings, wsgi, and middleware classes)
- adds `CalcList` and `CalcListItem` models and registers with `AutocompleterDictProvider`

### To Test
- [ ] `python manage.py makemigrations`
- [ ] `python manage.py migrate`
- [ ] `pip install -e .`
- [ ] `python manage.py autocompleter_init --name metric --store`
- [ ] `python manage.py shell`
```
from test_app.models import CalcList, CalcListItem
calc_list = CalcList.objects.create(name='New Metric set')

calc_list_item = CalcListItem.objects.create(calc_list=calc_list, calc_name='P/E')
```
- [ ] go to the admin, check on the `CalcList` object that you've created. The field value, should be populated with `'PE Ratio TTM'`. You can `inspect` the element, and check out the `HiddenInput`. It should be populated with `'P/E'`


