### PR TITLE
Part 4 + 5: adds js + css for autocompleter result items

### DIFF
--- a/autocompleter/static/autocompleter/css/dj.autocompleter.css
+++ b/autocompleter/static/autocompleter/css/dj.autocompleter.css
@@ -1,16 +1,22 @@
 ul.autocompleter-results-list {
-}
-
-ul.autocompleter-results-list ul {
-  margin-left: 0;
+  margin: 0;
+  padding: 0;
+  max-width: 600px;
 }
 
 ul.autocompleter-results-list li.provider-name {
   font-weight: 900;
 }
 
+ul.autocompleter-results-list li {
+  list-style: none;
+  padding: 5px;
+  font-size: 13px;
+}
+
 ul.autocompleter-results-list li.result-item {
   cursor: pointer;
+  border-bottom: 1px solid darkgray;
 }
 
 ul.autocompleter-results-list li.result-item:hover{

--- a/autocompleter/static/autocompleter/css/dj.autocompleter.css
+++ b/autocompleter/static/autocompleter/css/dj.autocompleter.css
@@ -1,0 +1,18 @@
+ul.autocompleter-results-list {
+}
+
+ul.autocompleter-results-list ul {
+  margin-left: 0;
+}
+
+ul.autocompleter-results-list li.provider-name {
+  font-weight: 900;
+}
+
+ul.autocompleter-results-list li.result-item {
+  cursor: pointer;
+}
+
+ul.autocompleter-results-list li.result-item:hover{
+  background: #eeffee;
+}

--- a/autocompleter/static/autocompleter/js/dj.autocompleter.js
+++ b/autocompleter/static/autocompleter/js/dj.autocompleter.js
@@ -1,0 +1,63 @@
+(function ($) {
+    const autocompleterSelectField = function () {
+        const self = $(this);
+        const parent = self.parent();
+        const dataField = parent.find('input[type=hidden]');
+
+        // set options
+        const options = {
+            url: self.data('autocompleter-url'),
+            databaseField: self.data('autocompleter-db-field'),
+            displayNameField: self.data('autocompleter-name-field')
+        };
+
+        const removeSearchResults = function () {
+            parent.find('ul, li').remove();
+        };
+
+        const listItemClick = function (event) {
+            const value = $(this).data('value');
+            self.val($(this).text());
+            dataField.val(value);
+            removeSearchResults();
+        };
+
+        const autocompleterCallback = function (searchResults) {
+            // parse data, put into <li> items
+            removeSearchResults();
+            const resultsList = $('<ul class="autocompleter-results-list"></ul>');
+            if (searchResults.length) {
+                searchResults.forEach((searchResult) => {
+                    const listItem = $(`<li class="result-item" ` +
+                        `data-value="${searchResult[options.databaseField]}">` +
+                        `${searchResult[options.displayNameField]}</li>`);
+                    listItem.on('click', listItemClick);
+                    resultsList.append(listItem);
+                });
+            } else {
+                const query = $(self).val();
+                const noResult = $(`<li>There are no results for "${query}"</li>`);
+                resultsList.append(noResult);
+            }
+            parent.append(resultsList);
+        };
+
+        const suggest = function () {
+            const query = {
+                q: $(self).val(),
+            };
+            $.getJSON(options.url, query, autocompleterCallback);
+        };
+        self.on('keyup', suggest);
+    };
+
+    $.fn.extend({
+        bindAutocompleterSelectField: autocompleterSelectField,
+    });
+
+    $(document).ready(() => {
+        $('input[data-autocompleter]').each(function () {
+            $(this).bindAutocompleterSelectField();
+        });
+    });
+}(django.jQuery));


### PR DESCRIPTION
### Overview

- binds `bindAutocompleterSelectField` to `jQuery` (which is loaded in django admin)
- on `keyup`, does an AC suggest lookup and displays the results.
- works for multiple fields on the page.
- adds some styling for the result items that come back from the AC

### How to Test
- [ ] go to same page as Part 3 (`SecurityItem`), and start typing search terms.
- [ ] click on one of the results and make sure the search field is populated. 
- [ ] hit "Save & continue editing". It should load the value of that field correctly. 
