### PR TITLE
Update to redis 3.0 capable, reorder setex args (StrictRedis), update…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-django-autocompleter
-================
 django-autocompleter is a redis-backed autocompleter for Django. It provides, fast, seamless autocompletion for Django models with a minimum of effort.

--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 3)
+VERSION = (0, 7, 4)
 
 from autocompleter.registry import registry, signal_registry
 from autocompleter.base import AutocompleterBase, AutocompleterModelProvider, AutocompleterDictProvider, Autocompleter

--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 4)
+VERSION = (0, 8, 0)
 
 from autocompleter.registry import registry, signal_registry
 from autocompleter.base import AutocompleterBase, AutocompleterModelProvider, AutocompleterDictProvider, Autocompleter

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -305,7 +305,7 @@ class AutocompleterProviderBase(AutocompleterBase):
                     word_prefix += char
                     # Store prefix to obj ID mapping, with score
                     key = PREFIX_BASE_NAME % (provider_name, word_prefix,)
-                    pipe.zadd(key, obj_id, score)
+                    pipe.zadd(key, {obj_id: score})
                     # Store autocompleter to prefix mapping so we know all prefixes
                     # of an autocompleter
                     key = PREFIX_SET_BASE_NAME % (provider_name,)
@@ -320,7 +320,7 @@ class AutocompleterProviderBase(AutocompleterBase):
                     continue
                 # Store exact term to obj ID mapping, with score
                 key = EXACT_BASE_NAME % (provider_name, norm_term,)
-                pipe.zadd(key, obj_id, score)
+                pipe.zadd(key, {obj_id: score})
 
                 # Store autocompleter to exact term mapping so we know all exact terms
                 # of an autocompleter
@@ -329,7 +329,7 @@ class AutocompleterProviderBase(AutocompleterBase):
 
         for facet in facet_dicts:
             key = FACET_SET_BASE_NAME % (provider_name, facet['key'], facet['value'],)
-            pipe.zadd(key, obj_id, score)
+            pipe.zadd(key, {obj_id: score})
 
         # Map provider's obj_id -> data payload
         key = AUTO_BASE_NAME % (provider_name,)
@@ -759,7 +759,7 @@ class Autocompleter(AutocompleterBase):
 
         # If told to, cache the final results for CACHE_TIMEOUT secnds
         if settings.CACHE_TIMEOUT:
-            REDIS.setex(cache_key, self.__class__._serialize_data(results), settings.CACHE_TIMEOUT)
+            REDIS.setex(cache_key, settings.CACHE_TIMEOUT, self.__class__._serialize_data(results))
         return results
 
     def exact_suggest(self, term):
@@ -814,7 +814,7 @@ class Autocompleter(AutocompleterBase):
 
         # If told to, cache the final results for CACHE_TIMEOUT seconds
         if settings.CACHE_TIMEOUT:
-            REDIS.setex(cache_key, self.__class__._serialize_data(results), settings.CACHE_TIMEOUT)
+            REDIS.setex(cache_key, settings.CACHE_TIMEOUT, self.__class__._serialize_data(results))
         return results
 
     def get_provider_result_from_id(self, provider_name, object_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Core packages needed
 Django>=1.8
-hiredis
-redis>=2.4.10
+hiredis>=1.0
+redis>=3.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-autocompleter',
-    version="0.7.3",
+    version="0.7.4",
     description='A redis-backed autocompletor for Django projects',
     author='Ara Anjargolian',
     author_email='ara818@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-autocompleter',
-    version="0.7.4",
+    version="0.8.0",
     description='A redis-backed autocompletor for Django projects',
     author='Ara Anjargolian',
     author_email='ara818@gmail.com',


### PR DESCRIPTION

- make redis min requirement 3.0, hiredis 1.0
- update zadd to take `name` `mapping` args
- reorder args of `setex` as per `StrictRedis` use

### TESTING
- [ ] in `/sites/ycharts` checkout into origin branch `update_redis`
- [ ] `vagrant up bionic --provision`
- [ ] `vagrant ssh bionic`
- [ ] `pip install file:///sites/django-autocompleter`
- [ ] `yc_django` test out autocompleter, make sure it is working and not throwing AttributeErrors on the `setex` calls