### PR TITLE
use sha1 instead of built in hash function

### DIFF
--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 8, 2)
+VERSION = (0, 8, 3)
 
 from autocompleter.registry import registry, signal_registry
 from autocompleter.base import AutocompleterBase, AutocompleterModelProvider, AutocompleterDictProvider, Autocompleter

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from hashlib import sha1
 import redis
 import json
 import itertools
@@ -863,6 +864,9 @@ class Autocompleter(AutocompleterBase):
         Given an array of facet data, return a deterministic hash such that
         the ordering of keys inside the facet dicts does not matter.
         """
+        def sha1_digest(my_str):
+            return sha1(my_str.encode(encoding='UTF-8')).hexdigest()
+
         facet_hashes = []
         for facet in facets:
             sub_facet_hashes = []
@@ -870,12 +874,12 @@ class Autocompleter(AutocompleterBase):
             sub_facets = facet['facets']
             for sub_facet in sub_facets:
                 sub_facet_str = 'key:' + sub_facet['key'] + 'value:' + str(sub_facet['value'])
-                sub_facet_hashes.append(hash(sub_facet_str))
+                sub_facet_hashes.append(sha1_digest(sub_facet_str))
             sub_facet_hashes.sort()
             facet_str = 'type:' + facet_type + 'facets:' + str(sub_facet_hashes)
-            facet_hashes.append(hash(facet_str))
+            facet_hashes.append(sha1_digest(facet_str))
         facet_hashes.sort()
-        final_facet_hash = hash(str(facet_hashes))
+        final_facet_hash = sha1_digest(str(facet_hashes))
         return final_facet_hash
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-autocompleter',
-    version="0.8.2",
+    version="0.8.3",
     description='A redis-backed autocompletor for Django projects',
     author='Ara Anjargolian',
     author_email='ara818@gmail.com',

--- a/test_project/test_app/tests/test_utils.py
+++ b/test_project/test_app/tests/test_utils.py
@@ -48,7 +48,7 @@ class TestFacetHash(TestCase):
                 'type': 'or',
                 'facets': [
                     {'key': 'sector', 'value': 'Technology'},
-                    {'key': 'industry', 'value': 'Software'}
+                    {'value': 'Software', 'key': 'industry'}
                 ]
             }
         ]
@@ -103,8 +103,8 @@ class TestFacetHash(TestCase):
             {
                 'type': 'or',
                 'facets': [
-                    {'key': 'sector', 'value': 'Technology'},
-                    {'key': 'industry', 'value': 'Software'}
+                    {'value': 'Technology', 'key': 'sector'},
+                    {'value': 'Software', 'key': 'industry'}
                 ]
             },
             {
@@ -127,7 +127,7 @@ class TestFacetHash(TestCase):
             {
                 'type': 'or',
                 'facets': [
-                    {'key': 'sector', 'value': 'Technology'},
+                    {'value': 'Technology', 'key': 'sector'},
                     {'key': 'industry', 'value': 'Software'}
                 ]
             },


### PR DESCRIPTION
### Overview
* Change built in hash function to sha1
* Change tests to ensure that order of key and value does not matter

### How to Test
`python manage.py test`