### PR TITLE
Django Autocompleter Setup for Redis upgrade

### DIFF
--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 8, 0)
+VERSION = (0, 10, 0)
 
 from autocompleter.registry import registry, signal_registry
 from autocompleter.base import AutocompleterBase, AutocompleterModelProvider, AutocompleterDictProvider, Autocompleter

--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 9, 0)
+VERSION = (0, 8, 0)
 
 from autocompleter.registry import registry, signal_registry
 from autocompleter.base import AutocompleterBase, AutocompleterModelProvider, AutocompleterDictProvider, Autocompleter

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -316,7 +316,7 @@ class AutocompleterProviderBase(AutocompleterBase):
                     word_prefix += char
                     # Store prefix to obj ID mapping, with score
                     key = PREFIX_BASE_NAME % (provider_name, word_prefix,)
-                    pipe.zadd(key, **{obj_id: score})
+                    pipe.zadd(key, {obj_id: score})
                     # Store autocompleter to prefix mapping so we know all prefixes
                     # of an autocompleter
                     key = PREFIX_SET_BASE_NAME % (provider_name,)
@@ -331,7 +331,7 @@ class AutocompleterProviderBase(AutocompleterBase):
                     continue
                 # Store exact term to obj ID mapping, with score
                 key = EXACT_BASE_NAME % (provider_name, norm_term,)
-                pipe.zadd(key, **{obj_id: score})
+                pipe.zadd(key, {obj_id: score})
 
                 # Store autocompleter to exact term mapping so we know all exact terms
                 # of an autocompleter
@@ -340,7 +340,7 @@ class AutocompleterProviderBase(AutocompleterBase):
 
         for facet in facet_dicts:
             key = FACET_SET_BASE_NAME % (provider_name, facet['key'], facet['value'],)
-            pipe.zadd(key, **{obj_id: score})
+            pipe.zadd(key, {obj_id: score})
 
         # Map provider's obj_id -> data payload
         key = AUTO_BASE_NAME % (provider_name,)

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -804,7 +804,7 @@ class Autocompleter(AutocompleterBase):
 
         # If told to, cache the final results for CACHE_TIMEOUT secnds
         if settings.CACHE_TIMEOUT:
-            REDIS.setex(cache_key, self.__class__._serialize_data(results), settings.CACHE_TIMEOUT)
+            REDIS.setex(cache_key, settings.CACHE_TIMEOUT, self.__class__._serialize_data(results))
         return results
 
     def exact_suggest(self, term):
@@ -859,7 +859,7 @@ class Autocompleter(AutocompleterBase):
 
         # If told to, cache the final results for CACHE_TIMEOUT seconds
         if settings.CACHE_TIMEOUT:
-            REDIS.setex(cache_key, self.__class__._serialize_data(results), settings.CACHE_TIMEOUT)
+            REDIS.setex(cache_key, settings.CACHE_TIMEOUT, self.__class__._serialize_data(results))
         return results
 
     def get_provider_result_from_id(self, provider_name, object_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Core packages needed
 Django>=1.8
-hiredis>=0.2.0,<=0.3.1
-redis>=2.4.10,<=2.10.6
+hiredis>=1.0
+redis>=3.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-autocompleter',
-    version="0.9.0",
+    version="0.10.0",
     description='A redis-backed autocompletor for Django projects',
     author='Ara Anjargolian',
     author_email='ara818@gmail.com',


### PR DESCRIPTION
1. Revert this commit: https://github.com/ycharts/django-autocompleter/commit/ca9881e24da522302c449f36be0a574d36c5332e
2. Revert this commit: https://github.com/ycharts/django-autocompleter/commit/73326273d175424a0af2202134e9dfa1a21de724
3. Bump version to latest dot release ( `0.10.0`)
