### PR TITLE
Add optional error handler arg to register and add/remove functions

### DIFF
--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 0, 2)
+VERSION = (1, 0, 3)
 
 from autocompleter.registry import registry, signal_registry
 from autocompleter.base import (

--- a/autocompleter/registry.py
+++ b/autocompleter/registry.py
@@ -278,5 +278,8 @@ class AutocompleterSignalRegistry(object):
             dispatch_uid=remove_uid,
         )
 
+        self.DISPATCH_ID_FUNCTION_MAPPING.pop(add_uid, None)
+        self.DISPATCH_ID_FUNCTION_MAPPING.pop(remove_uid, None)
+
 
 signal_registry = AutocompleterSignalRegistry()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Framework :: Django",
 ]
 dependencies = [
-    "Django >=3.2.*, <4.0",
+    "Django >=3.2.0, <4.0",
     "hiredis >= 1",
     "redis >= 3",
 ]

--- a/test_project/test_app/tests/test_storage.py
+++ b/test_project/test_app/tests/test_storage.py
@@ -483,8 +483,8 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
 
         signal_registry.unregister(Stock)
 
-    @patch('autocompleter.base.Autocompleter.store')
-    @patch('autocompleter.base.Autocompleter.remove')
+    @patch('autocompleter.base.AutocompleterProviderBase.store')
+    @patch('autocompleter.base.AutocompleterProviderBase.remove')
     def test_signal_based_add_and_remove_error_handlers(self, mock_remove, mock_store):
         """
         Turning on signals will automatically add and remove and object from the autocompleter

--- a/test_project/test_app/tests/test_storage.py
+++ b/test_project/test_app/tests/test_storage.py
@@ -500,10 +500,11 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
         signal_registry.register(Stock, add_error_handler=add_handler, remove_error_handler=remove_handler)
 
         aapl.save()
-        self.assertEqual(add_handler.call_count, 1)
+        # There are 2 autocompleter providers for the Stock model. Therefore expect two error handler calls
+        self.assertEqual(add_handler.call_count, 2)
 
         aapl.delete()
-        self.assertEqual(remove_handler.call_count, 1)
+        self.assertEqual(remove_handler.call_count, 2)
 
         signal_registry.unregister(Stock)
 

--- a/test_project/test_app/tests/test_storage.py
+++ b/test_project/test_app/tests/test_storage.py
@@ -496,20 +496,13 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
         mock_remove.side_effect = Exception()
         mock_store.side_effect = Exception()
         aapl = Stock(symbol="AAPL", name="Apple", market_cap=50)
-        aapl.save()
-        keys = self.redis.keys("djac.test.stock*")
-        self.assertEqual(len(keys), 0)
 
         signal_registry.register(Stock, add_error_handler=add_handler, remove_error_handler=remove_handler)
 
         aapl.save()
-        keys = self.redis.keys("djac.test.stock*")
-        self.assertNotEqual(len(keys), 0)
         self.assertEqual(add_handler.call_count, 1)
 
         aapl.delete()
-        keys = self.redis.keys("djac.test.stock*")
-        self.assertEqual(len(keys), 0)
         self.assertEqual(remove_handler.call_count, 1)
 
         signal_registry.unregister(Stock)


### PR DESCRIPTION
### Overview
There are some cases where we don't want autocompleter add/remove errors to raise an error. In this case we want to allow users provide an optional error handler at registration time for handling errors. Without these handlers the error will be raised as usual.

Example usage: https://github.com/ycharts/ycharts/pull/18664

### How to test
- [x] Unit tests pass
