### PR TITLE
Assign AppConfig as default

### DIFF
--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 0, 2)
+VERSION = (1, 0, 6)
 
 from autocompleter.registry import registry, signal_registry
 from autocompleter.base import (

--- a/autocompleter/apps.py
+++ b/autocompleter/apps.py
@@ -10,6 +10,7 @@ class SimpleAutocompleterConfig(AppConfig):
 
 class AutocompleterConfig(SimpleAutocompleterConfig):
     """The default AppConfig for autocompleter which does autodiscovery."""
+    default = True
 
     def ready(self):
         self.module.autodiscover()


### PR DESCRIPTION
### Overview
with our upgrade to Django 4 [we now need to specify which AppConfig to use as the default if there is more than 1](https://github.com/django/django/blob/4198a5cb2d3516130c26cff7e4a58754ebf0a47e/django/apps/config.py#L126-L144). This PR set's that default

### How to test
- [x] [tests](https://ycharts.slack.com/archives/C69TKJEUR/p1706209448374149) pass in `ycharts` repo
