### PR TITLE
Add update_all method

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,7 @@ jobs:
           flag-name: run-${{ matrix.python-version }}-${{ matrix.django-version }}
           path-to-lcov: coverage.lcov
           parallel: true
+          fail-on-error: false
 
   finish:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,6 @@ jobs:
           flag-name: run-${{ matrix.python-version }}-${{ matrix.django-version }}
           path-to-lcov: coverage.lcov
           parallel: true
-          fail-on-error: false
 
   finish:
     needs: build

--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,14 +1,13 @@
 VERSION = (1, 1, 0)
 
-from django.utils.module_loading import autodiscover_modules
-
+from autocompleter.registry import registry, signal_registry
 from autocompleter.base import (
     Autocompleter,
     AutocompleterBase,
     AutocompleterDictProvider,
     AutocompleterModelProvider,
 )
-from autocompleter.registry import registry, signal_registry
+from django.utils.module_loading import autodiscover_modules
 
 __all__ = [
     "registry",

--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,14 +1,14 @@
-VERSION = (1, 0, 6)
-
-from autocompleter.registry import registry, signal_registry
-from autocompleter.base import (
-    AutocompleterBase,
-    AutocompleterModelProvider,
-    AutocompleterDictProvider,
-    Autocompleter,
-)
+VERSION = (1, 1, 0)
 
 from django.utils.module_loading import autodiscover_modules
+
+from autocompleter.base import (
+    Autocompleter,
+    AutocompleterBase,
+    AutocompleterDictProvider,
+    AutocompleterModelProvider,
+)
+from autocompleter.registry import registry, signal_registry
 
 __all__ = [
     "registry",

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -298,7 +298,7 @@ class AutocompleterProviderBase(AutocompleterBase):
         for facet in self.get_facets():
             try:
                 facet_dicts.append({"key": facet, "value": data[facet]})
-            except AttributeError:
+            except KeyError:
                 pass
         return facet_dicts
 

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1073,12 +1073,14 @@ class Autocompleter(AutocompleterBase):
         else:
             return int(round(value))
 
-    def update_all(self):
+    def update_all(self, clear_cache=True):
         """
         WRITE SOMETHING COOL HERE
         """
         for provider_class in self._get_all_providers_by_autocompleter():
             self.update_provider(provider_class)
+        if clear_cache:
+            self.clear_cache()
 
     def update_provider(self, provider_class):
         """
@@ -1086,137 +1088,62 @@ class Autocompleter(AutocompleterBase):
         """
         provider_name = provider_class.get_provider_name()
         obj_score_map = dict()
-        # Init facets mapping
-        facets_live_set = set()
         facets_live_map = dict()
-        facets_live_list_of_dicts_map = dict()
-        # Init terms mappings
-        prefixes_live_set = set()
-        prefixes_db_set = set()
-        prefixes_live_map = dict()
-        prefixes_db_map = dict()
-
         terms_live_map = dict()
+        data_live_map = dict()
+
         for obj in provider_class.get_iterator():
             provider = provider_class(obj)
-            obj_id = provider.get_item_id()
+            obj_id = str(provider.get_item_id())
+            data = provider.get_data()
+            data_live_map[obj_id] = data
 
             # Mantain a mapping of each obj's score for later insertion into the sorted sets
             obj_score_map[obj_id] = provider._get_score()
 
+            # Mantain a mapping of each obj's norm terms
             terms = provider.get_terms()
-            # TODO: Look into improving performance here
             norm_terms = provider.__class__._get_norm_terms(terms) or []
-            old_norm_terms = provider.__class__.get_old_norm_terms(obj_id) or []
-
             terms_live_map[obj_id] = norm_terms
 
-            # We store each obj's current prefixes (i.e. live data) and old prefixes (i.e. data in
-            # db) and store them in sets for quick comparisons. We use frozensets because we will be
-            # inserting them later in another set and need the data structure to be hashable (normal
-            # sets aren't hashable, only immutable ones)
-            live_obj_prefixes = frozenset(
-                word[:x]
-                for norm_term in norm_terms
-                for word in norm_term.split(" ")
-                for x in range(1, len(word) + 1)
-            )
-            db_obj_prefixes = frozenset(
-                {
-                    word[:x]
-                    for old_norm_term in old_norm_terms
-                    for word in old_norm_term.split(" ")
-                    for x in range(1, len(word) + 1)
-                }
-            )
-            # TODO: Look if we can remove this high level set completely
-            # Add a tuple of the form (obj_id, {obj_prefixes_set}) into a high-level set of all
-            # objects within the provider for quick comparison
-            prefixes_live_set.add((obj_id, live_obj_prefixes))
-            prefixes_db_set.add((obj_id, db_obj_prefixes))
-            # Since sets are not subscriptable, we mantain a mapping of obj_ids and set of prefixes
-            # to have an accessible reference later on
-            prefixes_live_map[obj_id] = live_obj_prefixes
-            prefixes_db_map[obj_id] = db_obj_prefixes
-
             facets = provider.get_facets()
-            data = provider.get_data()
             facet_dicts = []
             for facet in facets:
                 try:
                     facet_dicts.append({"key": facet, "value": data[facet]})
                 except KeyError:
                     continue
-            # Mantain a mapping of each obj's facets list of dicts to store it in DB later if needed
-            facets_live_list_of_dicts_map[obj_id] = facet_dicts
-            # Also mantain a set of (obj_id, {obj_facets}) tuples
-            facets_set = frozenset({(f["key"], f["value"]) for f in facet_dicts})
-            facets_live_set.add((obj_id, facets_set))
-            facets_live_map[obj_id] = facets_set
-
-        #########
-        # FACETS
-        #########
-
-        # Fetch all the facets in the DB in a single query.
-        # We take advantage that Python dicts are ordered, so keys() always returns the same ordered
-        # list to build the mapping of facets in DB and compare them
-        facet_map_key = FACET_MAP_BASE_NAME % provider_class.get_provider_name()
-        facets_db_list_of_dicts_map = {
-            obj_id: self._deserialize_data(facets or b"[]")  # BAD HACK
-            for obj_id, facets in zip(
-                facets_live_map.keys(),
-                REDIS.hmget(facet_map_key, facets_live_map.keys()),
-            )
-        }
-        facets_db_map = {
-            obj_id: frozenset((f["key"], f["value"]) for f in facet_list_of_dicts)
-            for obj_id, facet_list_of_dicts in facets_db_list_of_dicts_map.items()
-        }
-        # Build the DB facets into a set for quick comparisons
-        facets_db_set = {
-            (obj_id, facets_set) for obj_id, facets_set in facets_db_map.items()
-        }
-        objs_with_updated_facets = facets_live_set ^ facets_db_set
-        for obj_id, _ in objs_with_updated_facets:
-            live_obj_facets = facets_live_map[obj_id]
-            db_obj_facets = facets_db_map[obj_id]
-
-            for key, value in live_obj_facets - db_obj_facets:
-                key = FACET_SET_BASE_NAME % (provider_name, key, value)
-                REDIS.zadd(key, {obj_id: obj_score_map[obj_id]})
-            for key, value in db_obj_facets - live_obj_facets:
-                key = FACET_SET_BASE_NAME % (provider_name, key, value)
-                REDIS.zrem(key, obj_id)
-
-        # Bulk update all needed facets in a single operation
-        facets_to_update = {
-            obj_id: self._serialize_data(facets_live_list_of_dicts_map[obj_id])
-            for obj_id, _ in facets_live_set - facets_db_set
-        }
-        if facets_to_update:
-            REDIS.hset(facet_map_key, mapping=facets_to_update)
-
-        # Keys that are present in DB but not in the live data indicate objects
-        # that were deleted. We remove them all in one operation
-        obj_deleted = set(facets_db_map.keys()) - set(
-            facets_live_list_of_dicts_map.keys()
-        )
-        if obj_deleted:
-            REDIS.hdel(facet_map_key, obj_deleted)
+            # Mantain a mapping of each obj's facets list of dicts
+            facets_live_map[obj_id] = facet_dicts
 
         ############
-        # NORM TERMS
+        # PREFIXES
         ############
-        # Since we're comparing sets whose elements have the form (obj_id, {set of terms}), then any
-        # difference between old and new terms will show up in the symmetric difference between the two
-        objs_with_updated_terms = prefixes_live_set ^ prefixes_db_set
-        for obj_id, _ in objs_with_updated_terms:
+        terms_map_key = TERM_MAP_BASE_NAME % provider_name
+        # Fetch all terms from the DB in a single query and build a map of them with obj_id as key
+        terms_db_map = {
+            str(self._deserialize_data(obj_id)): self._deserialize_data(terms)
+            for obj_id, terms in REDIS.hgetall(terms_map_key).items()
+        }
+        # Build the prefixes into sets for quick comparisons
+        prefixes_db_set = {
+            (obj_id, self._get_prefixes_set(norm_terms))
+            for obj_id, norm_terms in terms_db_map.items()
+        }
+
+        prefixes_live_set = {
+            (obj_id, self._get_prefixes_set(norm_terms))
+            for obj_id, norm_terms in terms_live_map.items()
+        }
+        # Since we're comparing sets whose elements have the form (obj_id, {set of prefixes}), then any
+        # difference between old and new terms will show up in the symmetric difference
+        objs_with_updated_prefixes = prefixes_live_set ^ prefixes_db_set
+        for obj_id, _ in objs_with_updated_prefixes:
             # Symmetric difference tells us which objects need to be updated but we don't know
             # which element comes from which set, so we retrieve the prefixes from the prefix mappings to
             # compare them
-            live_obj_prefixes = prefixes_live_map[obj_id]
-            db_obj_prefixes = prefixes_db_map[obj_id]
+            live_obj_prefixes = self._get_prefixes_set(terms_live_map.get(obj_id, []))
+            db_obj_prefixes = self._get_prefixes_set(terms_db_map.get(obj_id, []))
 
             # Prefixes in the live set but not in the DB are new prefixes found in its terms
             for prefix in live_obj_prefixes - db_obj_prefixes:
@@ -1228,7 +1155,7 @@ class Autocompleter(AutocompleterBase):
                 key = PREFIX_BASE_NAME % (provider_name, prefix)
                 REDIS.zrem(key, obj_id)
 
-        # Do relevant updates to high-level prefix set within the provider
+        # Build a single set of all prefixes in each data set
         all_prefixes_in_db = {
             x for _, prefix_set in prefixes_db_set for x in prefix_set
         }
@@ -1236,24 +1163,139 @@ class Autocompleter(AutocompleterBase):
             x for _, prefix_set in prefixes_live_set for x in prefix_set
         }
 
-        key = PREFIX_SET_BASE_NAME % (provider_name,)
+        # Do relevant updates to high-level prefix set within the provider
+        prefixes_set_key = PREFIX_SET_BASE_NAME % (provider_name,)
         if to_remove := all_prefixes_in_db - all_prefixes_in_live_data:
-            REDIS.srem(key, *to_remove)
+            REDIS.srem(prefixes_set_key, *to_remove)
         if to_add := all_prefixes_in_live_data - all_prefixes_in_db:
-            REDIS.sadd(key, *to_add)
-
-        if obj_ids_with_updated_terms := {
-            obj_id for obj_id, _ in objs_with_updated_terms
-        }:
-            mapping = {
-                obj_id: self._serialize_data(terms_live_map[obj_id])
-                for obj_id in obj_ids_with_updated_terms
-            }
-            REDIS.hset(
-                TERM_MAP_BASE_NAME % provider_name,
-                mapping=mapping,
-            )
+            REDIS.sadd(prefixes_set_key, *to_add)
 
         #############
         # EXACT TERMS
         #############
+        # Build the terms into sets for quick comparisons
+        terms_db_set = {
+            (obj_id, frozenset(terms)) for obj_id, terms in terms_db_map.items()
+        }
+        terms_live_set = {
+            (obj_id, frozenset(terms)) for obj_id, terms in terms_live_map.items()
+        }
+        max_word_count = registry.get_provider_setting(
+            provider, "MAX_EXACT_MATCH_WORDS"
+        )
+        objs_with_updated_terms = terms_live_set ^ terms_db_set
+        for obj_id, _ in objs_with_updated_terms:
+            # Same as before, we need to fetch the terms in each data set from the mapping to
+            # compare them
+            live_obj_terms = frozenset(terms_live_map.get(obj_id, []))
+            db_obj_terms = frozenset(terms_db_map.get(obj_id, []))
+            # Terms in the live set but not in the DB are new terms
+            for term in live_obj_terms - db_obj_terms:
+                # Terms only get added if there are less than MAX_EXACT_MATCH_WORDS words
+                if len(term.split(" ")) <= max_word_count:
+                    key = EXACT_BASE_NAME % (provider_name, term)
+                    REDIS.zadd(key, {obj_id: obj_score_map[obj_id]})
+            # Terms in the DB but not in the live set are terms that got removed
+            for term in db_obj_terms - live_obj_terms:
+                key = EXACT_BASE_NAME % (provider_name, term)
+                REDIS.zrem(key, obj_id)
+
+        # Build a single set of all terms in each data set
+        all_terms_in_db = {x for _, term_set in terms_db_set for x in term_set}
+        all_terms_in_live_data = {x for _, term_set in terms_live_set for x in term_set}
+        exact_set_key = EXACT_SET_BASE_NAME % provider_name
+        # Update the high-level set of exact terms in the provider in two operations
+        if to_add := all_terms_in_live_data - all_terms_in_db:
+            REDIS.sadd(exact_set_key, *to_add)
+        if to_remove := all_terms_in_db - all_terms_in_live_data:
+            REDIS.srem(exact_set_key, *to_remove)
+
+        # Updte the high-level hash map of terms in a single operation
+        if to_add := terms_live_set - terms_db_set:
+            mapping = {
+                obj_id: self._serialize_data(terms_live_map[obj_id])
+                for obj_id, _ in to_add
+            }
+            REDIS.hset(terms_map_key, mapping=mapping)
+        # Keys that are present in DB but not in the live data indicate objects
+        # that were deleted. We remove them all in one operation
+        if to_remove := set(terms_db_map.keys()) - set(terms_live_map.keys()):
+            REDIS.hdel(terms_map_key, *to_remove)
+
+        #########
+        # FACETS
+        #########
+
+        # Fetch all the facets in the DB in a single query.
+        facet_map_key = FACET_MAP_BASE_NAME % provider_name
+        facets_db_map = {
+            str(self._deserialize_data(obj_id)): self._deserialize_data(facets)
+            for obj_id, facets in REDIS.hgetall(facet_map_key).items()
+        }
+
+        # Build the facets maps into sets for quick comparisons
+        facets_live_set = {
+            (obj_id, self._facet_list_to_set(list_of_dicts))
+            for obj_id, list_of_dicts in facets_live_map.items()
+        }
+        facets_db_set = {
+            (obj_id, self._facet_list_to_set(list_of_dicts))
+            for obj_id, list_of_dicts in facets_db_map.items()
+        }
+        # Compare the two sets to get the updated objects
+        objs_with_updated_facets = facets_live_set ^ facets_db_set
+        for obj_id, _ in objs_with_updated_facets:
+            live_obj_facets = self._facet_list_to_set(facets_live_map.get(obj_id, []))
+            db_obj_facets = self._facet_list_to_set(facets_db_map.get(obj_id, []))
+
+            for key, value in live_obj_facets - db_obj_facets:
+                key = FACET_SET_BASE_NAME % (provider_name, key, value)
+                REDIS.zadd(key, {obj_id: obj_score_map[obj_id]})
+            for key, value in db_obj_facets - live_obj_facets:
+                key = FACET_SET_BASE_NAME % (provider_name, key, value)
+                REDIS.zrem(key, obj_id)
+
+        # Bulk update the facets hash map with all needed facets in a single operation
+        if facets_with_updates := facets_live_set - facets_db_set:
+            mapping = {
+                obj_id: self._serialize_data(facets_live_map[obj_id])
+                for obj_id, _ in facets_with_updates
+            }
+            REDIS.hset(facet_map_key, mapping=mapping)
+
+        # Keys that are present in DB but not in the live data indicate objects
+        # that were deleted. We remove them all in one operation
+        if obj_deleted := set(facets_db_map.keys()) - set(facets_live_map.keys()):
+            REDIS.hdel(facet_map_key, *obj_deleted)
+
+        #####################
+        # Data
+        #####################
+
+        data_map_key = AUTO_BASE_NAME % provider_name
+        data_db_map = {
+            self._deserialize_data(obj_id): self._deserialize_data(data)
+            for obj_id, data in REDIS.hgetall(data_map_key).items()
+        }
+        data_updated = {
+            obj_id: self._serialize_data(data)
+            for obj_id, data in data_live_map.items()
+            if data != data_db_map.get(obj_id, {})
+        }
+        if data_updated:
+            REDIS.hset(data_map_key, mapping=data_updated)
+        if objs_removed := set(data_db_map.keys()) - set(data_live_map.keys()):
+            REDIS.hdel(data_map_key, *objs_removed)
+
+    def _facet_list_to_set(self, facet_list):
+        return frozenset((f["key"], f["value"]) for f in facet_list)
+
+    def _get_prefixes_set(self, norm_terms_list):
+        return frozenset(
+            {
+                word[:x]
+                for norm_term in norm_terms_list
+                for word in norm_term.split(" ")
+                for x in range(1, len(word) + 1)
+            }
+        )

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -39,7 +39,7 @@ FACET_MAP_BASE_NAME = AUTO_BASE_NAME + ".fm"
 
 RESULT_SET_BASE_NAME = "djac.results.%s"
 
-SCORE_MAP_BASE_NAME = AUTO_BASE_NAME + ".sc"
+SCORE_MAP_BASE_NAME = AUTO_BASE_NAME + ".sm"
 
 
 class AutocompleterBase(object):
@@ -1145,7 +1145,7 @@ class Autocompleter(AutocompleterBase):
         2. EXACT TERMS: Updates to ZSET djac.provider.e.obj_id, SET djac.provider.es and HASH djac.provider.tm
         3. FACETS: Updates to ZSET djac.provider.f.key.value and HASH djac.provider.fm
         4. DATA: Updates to HASH djac.provider
-        5. SCORES: Updates to HASH djac.provider.sc
+        5. SCORES: Updates to HASH djac.provider.sm
 
         Throughout the method, the different data structures variables use the following convention:
                              <data>_<origin>_<data_structure>

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1248,13 +1248,13 @@ class Autocompleter(AutocompleterBase):
                 else live_obj_prefixes - db_obj_prefixes
             )
             for prefix in prefixes_to_add:
-                key = PREFIX_BASE_NAME % (provider_name, prefix)
-                pipe.zadd(key, {obj_id: scores_live_map[obj_id]})
+                prefix_sorted_set_key = PREFIX_BASE_NAME % (provider_name, prefix)
+                pipe.zadd(prefix_sorted_set_key, {obj_id: scores_live_map[obj_id]})
 
             # Prefixes in the DB but not in the live set are prefixes that got removed
             for prefix in db_obj_prefixes - live_obj_prefixes:
-                key = PREFIX_BASE_NAME % (provider_name, prefix)
-                pipe.zrem(key, obj_id)
+                prefix_sorted_set_key = PREFIX_BASE_NAME % (provider_name, prefix)
+                pipe.zrem(prefix_sorted_set_key, obj_id)
 
         # Build a single set of all prefixes in each data set
         all_prefixes_in_db = {
@@ -1304,12 +1304,12 @@ class Autocompleter(AutocompleterBase):
             for term in terms_to_add:
                 # Terms only get added if there are less than MAX_EXACT_MATCH_WORDS words
                 if len(term.split(" ")) <= max_word_count:
-                    key = EXACT_BASE_NAME % (provider_name, term)
-                    pipe.zadd(key, {obj_id: scores_live_map[obj_id]})
+                    exact_sorted_set_key = EXACT_BASE_NAME % (provider_name, term)
+                    pipe.zadd(exact_sorted_set_key, {obj_id: scores_live_map[obj_id]})
             # Terms in the DB but not in the live set are terms that got removed
             for term in db_obj_terms - live_obj_terms:
-                key = EXACT_BASE_NAME % (provider_name, term)
-                pipe.zrem(key, obj_id)
+                exact_sorted_set_key = EXACT_BASE_NAME % (provider_name, term)
+                pipe.zrem(exact_sorted_set_key, obj_id)
 
         # Build a single set of all terms in each data set
         all_terms_in_db = {x for _, term_set in terms_db_set for x in term_set}
@@ -1367,11 +1367,11 @@ class Autocompleter(AutocompleterBase):
                 else live_obj_facets - db_obj_facets
             )
             for key, value in facets_to_add:
-                key = FACET_SET_BASE_NAME % (provider_name, key, value)
-                pipe.zadd(key, {obj_id: scores_live_map[obj_id]})
+                facet_sorted_set_key = FACET_SET_BASE_NAME % (provider_name, key, value)
+                pipe.zadd(facet_sorted_set_key, {obj_id: scores_live_map[obj_id]})
             for key, value in db_obj_facets - live_obj_facets:
-                key = FACET_SET_BASE_NAME % (provider_name, key, value)
-                pipe.zrem(key, obj_id)
+                facet_sorted_set_key = FACET_SET_BASE_NAME % (provider_name, key, value)
+                pipe.zrem(facet_sorted_set_key, obj_id)
 
         # Bulk update the facets hash map with all needed facets in a single operation
         if facets_with_updates := facets_live_set - facets_db_set:

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1139,8 +1139,8 @@ class Autocompleter(AutocompleterBase):
 
         This method attempts to optimize the number of operations done on the Redis DB. The overall
         strategy for this is to create mappings (for quick references) and sets (for quick
-        comparisons) and preprocess operations as much as possible before htting the DB. This method
-        has 4 different main parts, each dealing with the relevant redis keys:
+        comparisons) and pre-process operations as much as possible before hitting the DB. This method
+        has 5 different parts, each dealing with the relevant redis keys:
         1. PREFIXES: Updates to ZSET djac.provider.p.prefix and HASH djac.provider.ps
         2. EXACT TERMS: Updates to ZSET djac.provider.e.obj_id, SET djac.provider.es and HASH djac.provider.tm
         3. FACETS: Updates to ZSET djac.provider.f.key.value and HASH djac.provider.fm
@@ -1152,7 +1152,7 @@ class Autocompleter(AutocompleterBase):
         where:
         * <data> - the actual data being stored: terms, facets, score or data
         * <origin> - where the data was taken from: live means current data and db means stored in redis
-        * <data_type> - data structure used to hold the data: either map or set
+        * <data_structure> - data structure used to hold the data: either map or set
         """
 
         def _facet_list_to_set(facet_list):
@@ -1182,15 +1182,15 @@ class Autocompleter(AutocompleterBase):
             data = provider.get_data()
             data_live_map[obj_id] = data
 
-            # Mantain a mapping of each obj's score for later insertion into the sorted sets
+            # Maintain a mapping of each obj's score for later insertion into the sorted sets
             scores_live_map[obj_id] = provider._get_score()
 
-            # Mantain a mapping of each obj's norm terms
+            # Maintain a mapping of each obj's norm terms
             terms = provider.get_terms()
             norm_terms = provider.__class__._get_norm_terms(terms) or []
             terms_live_map[obj_id] = norm_terms
 
-            # Mantain a mapping of each obj's facets list of dicts
+            # Maintain a mapping of each obj's facets list of dicts
             facets_live_map[obj_id] = provider.get_facets_dict()
 
         # Build a set with the obj_ids of objects that updated their score.
@@ -1321,7 +1321,7 @@ class Autocompleter(AutocompleterBase):
         if to_remove := all_terms_in_db - all_terms_in_live_data:
             pipe.srem(exact_set_key, *to_remove)
 
-        # Updte the high-level hash map of terms in a single operation
+        # Update the high-level hash map of terms in a single operation
         if to_add := terms_live_set - terms_db_set:
             mapping = {
                 obj_id: self._serialize_data(terms_live_map[obj_id])

--- a/autocompleter/management/commands/autocompleter_init.py
+++ b/autocompleter/management/commands/autocompleter_init.py
@@ -1,4 +1,3 @@
-from optparse import make_option
 import logging
 
 from django.core.management.base import BaseCommand
@@ -44,6 +43,14 @@ class Command(BaseCommand):
             help="Do not clear old terms from autocompleter when storing. "
             "Recommended only to be used with store all after remove_all otherwise orphan keys will remain.",
         )
+        parser.add_argument(
+            "--update",
+            action="store_true",
+            default=False,
+            dest="update",
+            help="Updates all autocompleter data. Only processes objects that have been modified. "
+            "Equivalent to --remove --clear_cache --store",
+        )
 
     help = "Store and/or remove autocompleter data"
 
@@ -70,3 +77,9 @@ class Command(BaseCommand):
         if options["clear_cache"]:
             self.log.info("Clearing cache for autocompleter: %s" % (options["name"]))
             autocomp.clear_cache()
+        if options["update"]:
+            self.log.info(
+                "Updating all objects with updates for autocompleter: %s"
+                % (options["name"])
+            )
+            autocomp.update_all()

--- a/autocompleter/utils.py
+++ b/autocompleter/utils.py
@@ -1,7 +1,7 @@
 import copy
+import itertools
 import re
 import unicodedata
-import itertools
 
 from autocompleter import settings
 
@@ -42,7 +42,7 @@ def get_normalized_term(term, replaced_chars=[]):
 
 def get_norm_term_variations(term):
     """
-    Get variations of a term in formalized form
+    Get variations of a term in normalized form
     """
     norm_terms = []
     # create list of what join chars we care about that are in the term

--- a/test_project/test_app/tests/base.py
+++ b/test_project/test_app/tests/base.py
@@ -1,5 +1,4 @@
 import redis
-
 from django.conf import settings
 from django.core import management
 from django.test import TestCase

--- a/test_project/test_app/tests/test_storage.py
+++ b/test_project/test_app/tests/test_storage.py
@@ -65,11 +65,11 @@ class StoringAndRemovingTestCase(AutocompleterTestCase):
         provider = StockAutocompleteProvider(aapl)
         provider.store()
 
-        keys = self.redis.hkeys("djac.test.stock.sc")
+        keys = self.redis.hkeys("djac.test.stock.sm")
         self.assertEqual(len(keys), 1)
 
         provider.remove()
-        keys = self.redis.hkeys("djac.test.stock.sc")
+        keys = self.redis.hkeys("djac.test.stock.sm")
         self.assertEqual(len(keys), 0)
 
     def test_dict_store_and_remove(self):

--- a/test_project/test_app/tests/test_storage.py
+++ b/test_project/test_app/tests/test_storage.py
@@ -2,18 +2,24 @@
 # -*- coding: utf-8 -*-
 
 
-from test_app.tests.base import AutocompleterTestCase
-from test_app.models import Stock, Indicator
+from unittest.mock import MagicMock, patch
+
+from autocompleter import Autocompleter, base, registry, signal_registry
+from autocompleter import settings as auto_settings
+from autocompleter.registry import (
+    add_obj_to_autocompleter,
+    remove_obj_from_autocompleter,
+)
+
+from test_app import calc_info
 from test_app.autocompleters import (
     CalcAutocompleteProvider,
     FacetedStockAutocompleteProvider,
+    IndicatorAliasedAutocompleteProvider,
     StockAutocompleteProvider,
 )
-from test_app import calc_info
-from autocompleter import base, Autocompleter, registry, signal_registry
-from autocompleter.registry import add_obj_to_autocompleter, remove_obj_from_autocompleter
-from autocompleter import settings as auto_settings
-from unittest.mock import patch, MagicMock
+from test_app.models import Indicator, Stock
+from test_app.tests.base import AutocompleterTestCase
 
 
 class StoringAndRemovingTestCase(AutocompleterTestCase):
@@ -484,8 +490,8 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
 
         signal_registry.unregister(Stock)
 
-    @patch('autocompleter.base.AutocompleterProviderBase.store')
-    @patch('autocompleter.base.AutocompleterProviderBase.remove')
+    @patch("autocompleter.base.AutocompleterProviderBase.store")
+    @patch("autocompleter.base.AutocompleterProviderBase.remove")
     def test_signal_based_add_and_remove_error_handlers(self, mock_remove, mock_store):
         """
         Errors are properly handled when add or remove signal is sent.
@@ -498,7 +504,9 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
         mock_store.side_effect = Exception()
         aapl = Stock(symbol="AAPL", name="Apple", market_cap=50)
 
-        signal_registry.register(Stock, add_error_handler=add_handler, remove_error_handler=remove_handler)
+        signal_registry.register(
+            Stock, add_error_handler=add_handler, remove_error_handler=remove_handler
+        )
 
         aapl.save()
         # There are 2 autocompleter providers for the Stock model. Therefore expect two error handler calls
@@ -509,8 +517,8 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
 
         signal_registry.unregister(Stock)
 
-    @patch('autocompleter.base.AutocompleterProviderBase.store')
-    @patch('autocompleter.base.AutocompleterProviderBase.remove')
+    @patch("autocompleter.base.AutocompleterProviderBase.store")
+    @patch("autocompleter.base.AutocompleterProviderBase.remove")
     def test_add_and_remove_error_handlers(self, mock_remove, mock_store):
         """
         Errors are properly handled when adding or removing manually
@@ -523,7 +531,13 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
         mock_store.side_effect = Exception()
         aapl = Stock(symbol="AAPL", name="Apple", market_cap=50)
 
-        add_obj_to_autocompleter(Stock, aapl, False, add_error_handler=add_handler, remove_error_handler=remove_handler)
+        add_obj_to_autocompleter(
+            Stock,
+            aapl,
+            False,
+            add_error_handler=add_handler,
+            remove_error_handler=remove_handler,
+        )
         # There are 2 autocompleter providers for the Stock model. Therefore expect two error handler calls
         self.assertEqual(add_handler.call_count, 2)
 
@@ -532,8 +546,8 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
 
         signal_registry.unregister(Stock)
 
-    @patch('autocompleter.base.AutocompleterProviderBase.store')
-    @patch('autocompleter.base.AutocompleterProviderBase.remove')
+    @patch("autocompleter.base.AutocompleterProviderBase.store")
+    @patch("autocompleter.base.AutocompleterProviderBase.remove")
     def test_unregister_removes_error_handlers(self, mock_remove, mock_store):
         """
         Unregistering removes registered error handling
@@ -545,7 +559,9 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
         mock_store.side_effect = Exception()
         aapl = Stock(symbol="AAPL", name="Apple", market_cap=50)
 
-        signal_registry.register(Stock, add_error_handler=add_handler, remove_error_handler=remove_handler)
+        signal_registry.register(
+            Stock, add_error_handler=add_handler, remove_error_handler=remove_handler
+        )
 
         # re register Stock without error handlers
         signal_registry.unregister(Stock)
@@ -598,3 +614,142 @@ class SignalBasedStoringTestCase(AutocompleterTestCase):
         registry.register("stock", StockAutocompleteProvider)
         providers = registry.get_all_by_autocompleter("stock")
         self.assertEqual(len(providers), 1)
+
+
+class UpdateTestCase(AutocompleterTestCase):
+    fixtures = ["stock_test_data_small.json", "indicator_test_data_small.json"]
+
+    def test_update_facets(self):
+        """
+        A
+        """
+
+        autocomp = Autocompleter("faceted_stock")
+        autocomp.store_all()
+
+        # Change AAPL's sector to 'Food'
+        aapl = Stock.objects.get(symbol="AAPL")
+        aapl.sector = "Food"
+        aapl.save()
+
+        # Original facets are ['sector', 'industry'] and we're patching them to ['sector', 'search_name']
+        with patch.object(
+            FacetedStockAutocompleteProvider,
+            "get_facets",
+            return_value=["sector", "search_name"],
+        ):
+            autocomp.update_all()
+
+        provider_name = FacetedStockAutocompleteProvider.get_provider_name()
+        facet_set_key = base.FACET_SET_BASE_NAME % (provider_name, "{}", "{}")
+        # AAPL is in djac.test.faceted_stock.sector.Food
+        self.assertIsNotNone(
+            self.redis.zscore(facet_set_key.format("sector", "Food"), aapl.id)
+        )
+        # AAPL is in djac.test.faceted_stock.search_symbol.AAPL
+        self.assertIsNotNone(
+            self.redis.zscore(facet_set_key.format("search_name", "AAPL"), aapl.id)
+        )
+
+        # AAPL is no longer in djac.test.faceted_stock.sector.Technology
+        self.assertIsNone(
+            self.redis.zscore(facet_set_key.format("sector", "Technology"), aapl.id)
+        )
+        # AAPL is no longer in djac.test.faceted_stock.industry.Consumer Electronics
+        self.assertIsNone(
+            self.redis.zscore(
+                facet_set_key.format("industry", "Consumer Electronics"), aapl.id
+            )
+        )
+        facet_map_key = base.FACET_MAP_BASE_NAME % (provider_name,)
+        facet_data = autocomp._deserialize_data(self.redis.hget(facet_map_key, aapl.id))
+        # Facet list was updated for AAPL in djac.test.faceted_stock
+        self.assertEqual(
+            facet_data,
+            [
+                {"key": "sector", "value": aapl.sector},
+                {"key": "search_name", "value": aapl.symbol},
+            ],
+        )
+
+    def test_terms_add_new_term(self):
+        """
+        A
+        """
+        autocomp = Autocompleter("indicator_aliased")
+        autocomp.store_all()
+
+        provider_name = IndicatorAliasedAutocompleteProvider.get_provider_name()
+        # Original name for indicator is "US Unemployment Rate"
+        unemployment = Indicator.objects.get(internal_name="unemployment_rate")
+        new_term = "xyzqwer"
+        unemployment.name += f" {new_term}"
+        unemployment.save()
+
+        autocomp.update_all()
+
+        # Verify that all new prefixes were added
+        new_prefixes = [new_term[:x] for x in range(1, len(new_term) + 1)]
+        for prefix in new_prefixes:
+            # Obj id lives in djac.test.indal.p.[x, xy, xyz, xyzq, ...]
+            prefix_key = base.PREFIX_BASE_NAME % (provider_name, prefix)
+            self.assertIsNotNone(self.redis.zscore(prefix_key, unemployment.id))
+
+            # The prefix is present in djac.test.indal.ps
+            self.assertTrue(
+                self.redis.sismember(base.PREFIX_SET_BASE_NAME % provider_name, prefix)
+            )
+
+        # Verify that the list of norm terms was updated in djac.test.indal
+        norm_terms_in_db = Autocompleter._deserialize_data(
+            self.redis.hget(base.TERM_MAP_BASE_NAME % provider_name, unemployment.id)
+        )
+        updated_norm_terms = IndicatorAliasedAutocompleteProvider._get_norm_terms(
+            IndicatorAliasedAutocompleteProvider(unemployment).get_terms()
+        )
+        self.assertEqual(norm_terms_in_db, updated_norm_terms)
+
+    def test_terms_remove_term(self):
+        """
+        A
+        """
+
+        # Modify the indicator's name before storing
+        unemployment = Indicator.objects.get(internal_name="unemployment_rate")
+        original_name = unemployment.name
+        new_term = "xyzqwer"
+        unemployment.name += f" {new_term}"
+        unemployment.save()
+
+        # Store them all
+        autocomp = Autocompleter("indicator_aliased")
+        autocomp.store_all()
+
+        # Update the indicator's name to its original name
+        unemployment = Indicator.objects.get(internal_name="unemployment_rate")
+        unemployment.name = original_name
+        unemployment.save()
+
+        # Update the autocompleter
+        autocomp.update_all()
+
+        provider_name = IndicatorAliasedAutocompleteProvider.get_provider_name()
+        # Verify that all removed prefixes were deleted
+        removed_prefixes = [new_term[:x] for x in range(1, len(new_term) + 1)]
+        for prefix in removed_prefixes:
+            # Obj id no longer lives in djac.test.indal.p.[x, xy, xyz, xyzq, ...]
+            prefix_key = base.PREFIX_BASE_NAME % (provider_name, prefix)
+            self.assertIsNone(self.redis.zscore(prefix_key, unemployment.id))
+
+            # The prefix is not present in djac.test.indal.ps
+            self.assertFalse(
+                self.redis.sismember(base.PREFIX_SET_BASE_NAME % provider_name, prefix)
+            )
+        # Verify that the list of norm terms was updated in djac.test.indal
+        norm_terms_in_db = Autocompleter._deserialize_data(
+            self.redis.hget(base.TERM_MAP_BASE_NAME % provider_name, unemployment.id)
+        )
+        updated_norm_terms = IndicatorAliasedAutocompleteProvider._get_norm_terms(
+            IndicatorAliasedAutocompleteProvider(unemployment).get_terms()
+        )
+        self.assertEqual(norm_terms_in_db, updated_norm_terms)


### PR DESCRIPTION
### Overview
Currently, the only way for changes to be reflected in the Autocompleter is to `remove_all`, then `store_all` and `remove_cache`. This makes for a slow and inefficient process because most of the objects weren't really updated. 

This PR introduces the method `update_all`, which in turn calls `update_provider` for each of the Autocompleter's provider. This method aims to significantly reduce the number of operations made on Redis by bulking them together as much as possible, as well as analyze the data in order to only deal with objects which were actually modified, leaving the rest untouched.
In order to do this, one of the main points was to add a new Redis hashmap `djac.provider.sc` which stores a mapping of obj_id -> score. This is done in order to have a reference to know when a given object has updated its score, since all objects use the same score across all the ranked sets.

I've tried documenting the method and the reasoning as much as possible, but I agree the whole implementation still feels bulky and somewhat convoluted. Any suggestions on making it leaner/more concise are very welcome

### How to test
- [ ] New test cases make sense and pass
