### PR TITLE
Add small check for when an ac doesn't have any providers

### DIFF
--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 1, 1)
+VERSION = (1, 1, 2)
 
 
 from autocompleter.registry import registry, signal_registry

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1146,6 +1146,7 @@ class Autocompleter(AutocompleterBase):
         Update all modified objects within all the ac's providers
         """
         if not (provider_classes := self._get_all_providers_by_autocompleter()):
+            self.log.warning(f"No providers for AC {self.name}. Skipping...")
             return
         for provider_class in provider_classes:
             self.update_provider(provider_class)

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1145,7 +1145,9 @@ class Autocompleter(AutocompleterBase):
         """
         Update all modified objects within all the ac's providers
         """
-        for provider_class in self._get_all_providers_by_autocompleter():
+        if not (provider_classes := self._get_all_providers_by_autocompleter()):
+            return
+        for provider_class in provider_classes:
             self.update_provider(provider_class)
         if clear_cache:
             self.clear_cache()


### PR DESCRIPTION
### Overview
In the `update_all` method, we iterate over all the providers of an autocompleter and update each one. If the ac doesn't have any providers, then an error is raised because we try to iterate over `None`
```
ERROR   2025-04-24 18:49:35,789 management_command Traceback (most recent call last):
  File "/sites/ycharts/apps/systems/management/commands/management_command.py", line 251, in handle
    self.run(command_run, *args, **options)
  File "/sites/ycharts/apps/systems/management/commands/autocompleter.py", line 69, in run
    autocomp.update_all()
  File "/usr/local/lib/python3.10/dist-packages/autocompleter/base.py", line 1148, in update_all
    for provider_class in self._get_all_providers_by_autocompleter():
TypeError: 'NoneType' object is not iterable
```

This PR adds a small check and exits early when there are no providers in the AC.

### How to test
- [ ] Step 1 to test the changes you made
- [ ] Step 2 to test the changes you made

