### PR TITLE
Quick Performance Updates

### DIFF
--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -603,7 +603,7 @@ class Autocompleter(AutocompleterBase):
 
             # Get list of facets
             facet_base = FACET_BASE_NAME % (provider_name,)
-            keys = [facet.decode() for facet in REDIS.keys(facet_base + ".*")]
+            keys = [facet.decode() for facet in REDIS.scan_iter(match=facet_base + ".*")]
             facet_keys = self.chunk_list(keys, 100)
 
             # Start pipeline
@@ -611,34 +611,34 @@ class Autocompleter(AutocompleterBase):
 
             # For each prefix, delete sorted set (in groups of 100)
             for chunk in chunked_prefix_keys:
-                pipe.delete(*chunk)
+                pipe.unlink(*chunk)
             # Delete the set of prefixes
-            pipe.delete(prefix_set_name)
+            pipe.unlink(prefix_set_name)
 
             # For each exact match term, delete sorted set (in groups of 100
             for chunk in chunked_norm_term_keys:
-                pipe.delete(*chunk)
+                pipe.unlink(*chunk)
             # Delete the set of exact matches
-            pipe.delete(exact_set_name)
+            pipe.unlink(exact_set_name)
 
             # For each facet, delete sorted set (in groups of 100)
             for chunk in facet_keys:
-                pipe.delete(*chunk)
+                pipe.unlink(*chunk)
             # Delete the facet mapping
             facet_map_name = FACET_MAP_BASE_NAME % (provider_name,)
-            pipe.delete(facet_map_name)
+            pipe.unlink(facet_map_name)
 
             # Remove provider's obj_id -> data payload mapping
             key = AUTO_BASE_NAME % (provider_name,)
-            pipe.delete(key)
+            pipe.unlink(key)
 
             # Remove provider's obj_id -> norm terms mapping
             key = TERM_MAP_BASE_NAME % (provider_name,)
-            pipe.delete(key)
+            pipe.unlink(key)
 
             # Remove provider's obj_id -> score mapping
             key = SCORE_MAP_BASE_NAME % (provider_name,)
-            pipe.delete(key)
+            pipe.unlink(key)
 
             # End pipeline
             pipe.execute()
@@ -652,13 +652,13 @@ class Autocompleter(AutocompleterBase):
             if not settings.TEST_DATA:
                 key = AUTO_BASE_NAME % (provider_name,)
                 key += "*"
-                leftovers = REDIS.keys(key)
+                leftovers = list(REDIS.scan_iter(match=key))
 
                 # Start pipeline
                 pipe = REDIS.pipeline()
 
                 for i in leftovers:
-                    pipe.delete(i)
+                    pipe.unlink(i)
 
                 # End pipeline
                 pipe.execute()
@@ -677,9 +677,9 @@ class Autocompleter(AutocompleterBase):
             "*",
         )
 
-        keys = REDIS.keys(cache_key) + REDIS.keys(exact_cache_key)
+        keys = list(REDIS.scan_iter(match=cache_key)) + list(REDIS.scan_iter(match=exact_cache_key))
         if len(keys) > 0:
-            REDIS.delete(*keys)
+            REDIS.unlink(*keys)
 
     def suggest(self, term, facets=[]):
         """
@@ -730,7 +730,7 @@ class Autocompleter(AutocompleterBase):
         # Get the max results autocompleter setting
         MAX_RESULTS = registry.get_autocompleter_setting(self.name, "MAX_RESULTS")
 
-        pipe = REDIS.pipeline()
+        pipe = REDIS.pipeline(transaction=False)
         for provider in providers:
             provider_name = provider.provider_name
 
@@ -862,7 +862,7 @@ class Autocompleter(AutocompleterBase):
                 else:
                     pipe.zrange(final_exact_match_key, 0, MAX_RESULTS - 1)
 
-        pipe.delete(*keys_to_delete)
+        pipe.unlink(*keys_to_delete)
 
         results = [i for i in pipe.execute() if type(i) == list]
 
@@ -1022,7 +1022,7 @@ class Autocompleter(AutocompleterBase):
         MAX_RESULTS = registry.get_autocompleter_setting(self.name, "MAX_RESULTS")
 
         # Get the matched result IDs
-        pipe = REDIS.pipeline()
+        pipe = REDIS.pipeline(transaction=False)
         for provider in providers:
             provider_name = provider.provider_name
             keys = []
@@ -1037,9 +1037,12 @@ class Autocompleter(AutocompleterBase):
             # Do not attempt zunionstore on empty list because redis errors out.
             if len(keys) == 0:
                 continue
-            pipe.zunionstore(intermediate_result_key, keys, aggregate="MIN")
-            pipe.zrange(intermediate_result_key, 0, MAX_RESULTS - 1)
-            pipe.delete(intermediate_result_key)
+            elif len(keys) == 1:
+                pipe.zrange(keys[0], 0, MAX_RESULTS - 1)
+            else:
+                pipe.zunionstore(intermediate_result_key, keys, aggregate="MIN")
+                pipe.zrange(intermediate_result_key, 0, MAX_RESULTS - 1)
+                pipe.unlink(intermediate_result_key)
         results = [i for i in pipe.execute() if type(i) == list]
 
         # Create a dict mapping provider to result IDs


### PR DESCRIPTION
### Overview
Autocompleter has had some recent struggles with performance. This PR doesn't aim to fix the main culprit (zunionstore calls), but attempts to fix some smaller/easier anti-patterns while a larger refactor for zunions are implemented.

- Prefer SCAN over KEYS. KEYS should really not be used production unless for special purposes (https://redis.io/docs/latest/commands/keys/), SCAN is much better as it won't block the server for a long period of time. (https://redis.io/docs/latest/commands/scan/)

- Prefer UNLINK over DEL. DEL is O(N) (https://redis.io/docs/latest/commands/del/) whereas UNLINK is O(1) (it uses a separate thread to handle the actual memory reclamation - that is still O(N) but we are happy since it doesn't happen on the main thread) (https://redis.io/docs/latest/commands/UNLINK/)

- For our suggest/exact_suggest call, we don't really depend on the call being transactional, so ideally this should help reduce the blocking window that could occur between concurrent suggest calls

### How to test
- [ ] tests pass