### PR TITLE
[Fix] Incomplete faceted search

### DIFF
--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -779,10 +779,24 @@ class Autocompleter(AutocompleterBase):
 
                     facet_list = facet_group["facets"]
                     facet_group_keys_set = set([sub_facet["key"] for sub_facet in facet_list])
-                    if not facet_group_keys_set.issubset(provider_keys_set):
-                        # For a given facet_group, if the provider does not support all the facet keys, then we can't
-                        # filter based on it, and we skip the facet_group
-                        continue
+                    if facet_type == "and":
+                        if not facet_group_keys_set.issubset(provider_keys_set):
+                            # AND requires all conditions to hold; if the provider can't evaluate
+                            # every key, the group is unsatisfiable — force empty results.
+                            empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                            facet_result_keys.append(empty_key)
+                            keys_to_delete.add(empty_key)
+                            facets_used = True
+                            continue
+                    else:
+                        facet_list = [f for f in facet_list if f["key"] in provider_keys_set]
+                        if not facet_list:
+                            # OR with no evaluable keys is unsatisfiable — force empty results.
+                            empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                            facet_result_keys.append(empty_key)
+                            keys_to_delete.add(empty_key)
+                            facets_used = True
+                            continue
 
                     facet_set_keys = []
                     for facet_dict in facet_list:

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -681,7 +681,7 @@ class Autocompleter(AutocompleterBase):
         if len(keys) > 0:
             REDIS.unlink(*keys)
 
-    def suggest(self, term, facets=[]):
+    def suggest(self, term, facets=[], *, strict=True):
         """
         Suggest matching objects, given a term
         """
@@ -778,24 +778,28 @@ class Autocompleter(AutocompleterBase):
                         continue
 
                     facet_list = facet_group["facets"]
-                    facet_group_keys_set = set([sub_facet["key"] for sub_facet in facet_list])
                     if facet_type == "and":
+                        facet_group_keys_set = set([sub_facet["key"] for sub_facet in facet_list])
                         if not facet_group_keys_set.issubset(provider_keys_set):
                             # AND requires all conditions to hold; if the provider can't evaluate
-                            # every key, the group is unsatisfiable — force empty results.
-                            empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
-                            facet_result_keys.append(empty_key)
-                            keys_to_delete.add(empty_key)
-                            facets_used = True
+                            # every key, the group is unsatisfiable
+                            if strict:
+                                # force empty results if suggestion is strict
+                                empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                                facet_result_keys.append(empty_key)
+                                keys_to_delete.add(empty_key)
+                                facets_used = True
                             continue
                     else:
                         facet_list = [f for f in facet_list if f["key"] in provider_keys_set]
                         if not facet_list:
-                            # OR with no evaluable keys is unsatisfiable — force empty results.
-                            empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
-                            facet_result_keys.append(empty_key)
-                            keys_to_delete.add(empty_key)
-                            facets_used = True
+                            # OR with no evaluable keys is unsatisfiable
+                            if strict:
+                                # force empty results if suggestion is strict
+                                empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                                facet_result_keys.append(empty_key)
+                                keys_to_delete.add(empty_key)
+                                facets_used = True
                             continue
 
                     facet_set_keys = []

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1095,10 +1095,24 @@ class Autocompleter(AutocompleterBase):
                     facet_group_keys_set = set(
                         [sub_facet["key"] for sub_facet in facet_list]
                     )
-                    if not facet_group_keys_set.issubset(provider_keys_set):
-                        # For a given facet_group, if the provider does not support all the facet keys, then we can't
-                        # filter based on it, and we skip the facet_group
-                        continue
+                    if facet_type == "and":
+                        if not facet_group_keys_set.issubset(provider_keys_set):
+                            # AND requires all conditions to hold; if the provider can't evaluate
+                            # every key, the group is unsatisfiable — force empty results.
+                            empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                            facet_result_keys.append(empty_key)
+                            keys_to_delete.add(empty_key)
+                            facets_used = True
+                            continue
+                    else:
+                        facet_list = [f for f in facet_list if f["key"] in provider_keys_set]
+                        if not facet_list:
+                            # OR with no evaluable keys is unsatisfiable — force empty results.
+                            empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                            facet_result_keys.append(empty_key)
+                            keys_to_delete.add(empty_key)
+                            facets_used = True
+                            continue
 
                     facet_set_keys = []
                     for facet_dict in facet_list:

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -994,7 +994,20 @@ class Autocompleter(AutocompleterBase):
 
     def suggest(self, term, facets=[], *, strict=True):
         """
-        Suggest matching objects, given a term
+        Suggest matching objects, given a term.
+
+        By default, suggest returns empty results for providers that can't satisfy all facets. For OR groups with a mix
+        of supported and unsupported keys, the unsupported keys are silently dropped and the rest are applied — this
+        behaves the same in both modes. Use strict=False to restore the old behavior where fully unsatisfiable groups
+        are skipped and results come back unfiltered.
+
+        ┌──────────────────────────────────────┬─────────────────────────────────┬─────────────────────────────┐
+        │             Facet Group              │   strict=True  (new default)    │        strict=False         │
+        ├──────────────────────────────────────┼─────────────────────────────────┼─────────────────────────────┤
+        │ AND(sector=Energy, fake_key=X)       │ empty results                   │ group skipped (unfiltered)  │
+        │ OR(sector=Energy, fake_key=X)        │ applies OR(sector=Energy)       │ applies OR(sector=Energy)   │
+        │ OR(fake_key=X, other_fake=Y)         │ empty results                   │ group skipped (unfiltered)  │
+        └──────────────────────────────────────┴─────────────────────────────────┴─────────────────────────────┘
         """
         providers = self._get_all_providers_by_autocompleter()
         if providers is None:

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -992,7 +992,7 @@ class Autocompleter(AutocompleterBase):
         """
         REDIS.incr(CACHE_VERSION_BASE_NAME % (self.name,))
 
-    def suggest(self, term, facets=[]):
+    def suggest(self, term, facets=[], *, strict=True):
         """
         Suggest matching objects, given a term
         """
@@ -1092,26 +1092,30 @@ class Autocompleter(AutocompleterBase):
                         continue
 
                     facet_list = facet_group["facets"]
-                    facet_group_keys_set = set(
-                        [sub_facet["key"] for sub_facet in facet_list]
-                    )
                     if facet_type == "and":
+                        facet_group_keys_set = set(
+                            [sub_facet["key"] for sub_facet in facet_list]
+                        )
                         if not facet_group_keys_set.issubset(provider_keys_set):
                             # AND requires all conditions to hold; if the provider can't evaluate
-                            # every key, the group is unsatisfiable — force empty results.
-                            empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
-                            facet_result_keys.append(empty_key)
-                            keys_to_delete.add(empty_key)
-                            facets_used = True
+                            # every key, the group is unsatisfiable
+                            if strict:
+                                # force empty results if suggestion is strict
+                                empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                                facet_result_keys.append(empty_key)
+                                keys_to_delete.add(empty_key)
+                                facets_used = True
                             continue
                     else:
                         facet_list = [f for f in facet_list if f["key"] in provider_keys_set]
                         if not facet_list:
-                            # OR with no evaluable keys is unsatisfiable — force empty results.
-                            empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
-                            facet_result_keys.append(empty_key)
-                            keys_to_delete.add(empty_key)
-                            facets_used = True
+                            # OR with no evaluable keys is unsatisfiable
+                            if strict:
+                                # force empty results if suggestion is strict
+                                empty_key = RESULT_SET_BASE_NAME % str(uuid.uuid4())
+                                facet_result_keys.append(empty_key)
+                                keys_to_delete.add(empty_key)
+                                facets_used = True
                             continue
 
                     facet_set_keys = []

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -453,10 +453,8 @@ class FacetMatchingTestCase(AutocompleterTestCase):
             }
         ]
         facet_matches = self.autocomp.suggest("a", facets=facets)
-        regular_matches = self.autocomp.suggest("a")
-        # since the 'thisisfake' key does not exist in our provider, the results for a facet
-        # suggest should be the same as a regular suggest
-        self.assertEqual(facet_matches, regular_matches)
+        # AND group with an unsupported key is unsatisfiable — provider returns empty results
+        self.assertEqual(len(facet_matches), 0)
 
     def test_provider_keys_is_subset_of_facet_keys_no_match(self):
         """
@@ -675,10 +673,10 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         }
         all_facets = facets + [extra_facet]
 
-        regular_matches = self.autocomp.suggest("ch", facets=facets)
         matches = self.autocomp.suggest("ch", facets=all_facets)
-        self.assertEqual(len(matches), 1)
-        self.assertEqual(regular_matches, matches)
+        # OR(fake_key, sector=Energy) drops fake_key, applies sector=Energy; but the AND groups
+        # require sector=Communication Services AND industry=Telecom Services — sector conflict → 0
+        self.assertEqual(len(matches), 0)
 
         facets = [
             {"type": "and", "facets": [{"key": "sector", "value": "Energy"}]},
@@ -692,10 +690,10 @@ class FacetMatchingTestCase(AutocompleterTestCase):
             "facets": [{"key": "fake_key", "value": "fake value"}, {"key": "sector", "value": "Communication Services"}],
         }
         all_facets = facets + [extra_facet]
-        regular_matches = self.autocomp.suggest("ch", facets=facets)
         matches = self.autocomp.suggest("ch", facets=all_facets)
-        self.assertEqual(len(matches), 2)
-        self.assertEqual(regular_matches, matches)
+        # OR(fake_key, sector=Communication Services) drops fake_key, applies sector=Communication Services;
+        # but AND groups require sector=Energy — sector conflict → 0
+        self.assertEqual(len(matches), 0)
 
 
 class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
@@ -727,9 +725,8 @@ class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
         self.assertEqual(len(matches["faceted_stock"]), 25)
         self.assertEqual(len(facet_matches["faceted_stock"]), 2)
 
-        # since the indicator provider does not support facets,
-        # we expect the search results from both a facet and non-facet search to be the same.
+        # the indicator provider supports no facet keys; the AND group is unsatisfiable → empty
         self.assertEqual(len(matches["ind"]), 16)
-        self.assertEqual(len(matches["ind"]), len(facet_matches["ind"]))
+        self.assertEqual(len(facet_matches["ind"]), 0)
 
         registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -750,6 +750,40 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         matches = self.autocomp.suggest("a", facets=facets)
         self.assertEqual(len(matches), 0)
 
+    def test_and_group_with_unsupported_key_lenient_returns_unfiltered(self):
+        """
+        AND facets group with unsupported key is skipped if strict=False, returns unfiltered results
+        """
+        facets = [
+            {
+                "type": "and",
+                "facets": [
+                    {"key": "sector", "value": "Energy"},
+                    {"key": "fake_key", "value": "anything"},
+                ],
+            }
+        ]
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+        regular_matches = self.autocomp.suggest("a")
+        self.assertEqual(facet_matches, regular_matches)
+
+    def test_or_group_with_all_unsupported_keys_lenient_returns_unfiltered(self):
+        """
+        OR group with all unsupported keys is skipped if strict=False, returns unfiltered results
+        """
+        facets = [
+            {
+                "type": "or",
+                "facets": [
+                    {"key": "fake_key", "value": "anything"},
+                    {"key": "other_fake", "value": "whatever"},
+                ],
+            }
+        ]
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+        regular_matches = self.autocomp.suggest("a")
+        self.assertEqual(facet_matches, regular_matches)
+
 
 class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
     fixtures = ["stock_test_data_small.json", "indicator_test_data_small.json"]
@@ -817,5 +851,29 @@ class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
 
         # indicator provider: supports no facets → all OR keys unsupported → empty
         self.assertEqual(len(matches["ind"]), 0)
+
+        registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
+
+    def test_non_facet_provider_lenient_returns_unfiltered(self):
+        """
+        non-facet provider skips unsatisfiable AND group if strict=False, returns unfiltered results
+        """
+        registry.set_autocompleter_setting(
+            "facet_stock_no_facet_ind", "MAX_RESULTS", 100
+        )
+        facets = [
+            {
+                "type": "and",
+                "facets": [{"key": "sector", "value": "Financial Services"}],
+            }
+        ]
+        matches = self.autocomp.suggest("a")
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+
+        # stock provider still filters normally
+        self.assertEqual(len(facet_matches["faceted_stock"]), 2)
+
+        # indicator provider: AND group skipped (lenient) → same results as unfiltered
+        self.assertEqual(len(facet_matches["ind"]), len(matches["ind"]))
 
         registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -452,9 +452,16 @@ class FacetMatchingTestCase(AutocompleterTestCase):
                 ],
             }
         ]
-        facet_matches = self.autocomp.suggest("a", facets=facets)
-        # AND group with an unsupported key is unsatisfiable — provider returns empty results
-        self.assertEqual(len(facet_matches), 0)
+        regular_matches = self.autocomp.suggest("a")
+        # since the 'thisisfake' key does not exist in our provider, the results for a facet
+        # suggest should be the same as a regular suggest if strict=False
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+        self.assertEqual(facet_matches, regular_matches)
+
+        # if strict=True, the AND group with an unsupported key is unsatisfiable, so provider returns empty results
+        strict_facet_matches = self.autocomp.suggest("a", facets=facets)
+        self.assertEqual(len(strict_facet_matches), 0)
+
 
     def test_provider_keys_is_subset_of_facet_keys_no_match(self):
         """
@@ -673,10 +680,14 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         }
         all_facets = facets + [extra_facet]
 
-        matches = self.autocomp.suggest("ch", facets=all_facets)
-        # OR(fake_key, sector=Energy) drops fake_key, applies sector=Energy; but the AND groups
-        # require sector=Communication Services AND industry=Telecom Services — sector conflict → 0
-        self.assertEqual(len(matches), 0)
+        regular_matches = self.autocomp.suggest("ch", facets=facets)
+        matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(regular_matches, matches)
+
+        # if we use strict search suggestions, results will be filtered out
+        strict_matches = self.autocomp.suggest("ch", facets=all_facets)
+        self.assertEqual(len(strict_matches), 0)
 
         facets = [
             {"type": "and", "facets": [{"key": "sector", "value": "Energy"}]},
@@ -690,9 +701,13 @@ class FacetMatchingTestCase(AutocompleterTestCase):
             "facets": [{"key": "fake_key", "value": "fake value"}, {"key": "sector", "value": "Communication Services"}],
         }
         all_facets = facets + [extra_facet]
-        matches = self.autocomp.suggest("ch", facets=all_facets)
-        # OR(fake_key, sector=Communication Services) drops fake_key, applies sector=Communication Services;
-        # but AND groups require sector=Energy — sector conflict → 0
+        regular_matches = self.autocomp.suggest("ch", facets=facets)
+        matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(regular_matches, matches)
+
+        # if we use strict search suggestions, results will be filtered out
+        strict_matches = self.autocomp.suggest("ch", facets=all_facets)
         self.assertEqual(len(matches), 0)
 
     def test_or_group_with_partial_keys_applies_supported_only(self):
@@ -807,16 +822,21 @@ class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
             }
         ]
         matches = self.autocomp.suggest("a")
-        facet_matches = self.autocomp.suggest("a", facets=facets)
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+        strict_facet_matches = self.autocomp.suggest("a", facets=facets)
 
         # because we are using the faceted stock provider in the 'facet_stock_no_facet_ind' AC,
         # we expect using facets will decrease the amount of results when searching.
         self.assertEqual(len(matches["faceted_stock"]), 25)
         self.assertEqual(len(facet_matches["faceted_stock"]), 2)
 
-        # the indicator provider supports no facet keys; the AND group is unsatisfiable → empty
+        # since the indicator provider does not support facets,
+        # we expect the search results from both a facet and non-facet search to be the same if strict=False
         self.assertEqual(len(matches["ind"]), 16)
-        self.assertEqual(len(facet_matches["ind"]), 0)
+        self.assertEqual(len(matches["ind"]), len(facet_matches["ind"]))
+
+        # if we use strict search suggestions, indicators will be filtered out
+        self.assertEqual(len(strict_facet_matches["ind"]), 0)
 
         registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
 

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -695,6 +695,61 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         # but AND groups require sector=Energy — sector conflict → 0
         self.assertEqual(len(matches), 0)
 
+    def test_or_group_with_partial_keys_applies_supported_only(self):
+        """
+        OR group with one unsupported key drops that key and applies the remaining supported keys
+        """
+        facets_partial = [
+            {
+                "type": "or",
+                "facets": [
+                    {"key": "sector", "value": "Energy"},
+                    {"key": "fake_key", "value": "anything"},
+                ],
+            }
+        ]
+        facets_full = [
+            {
+                "type": "or",
+                "facets": [{"key": "sector", "value": "Energy"}],
+            }
+        ]
+        partial_matches = self.autocomp.suggest("a", facets=facets_partial)
+        full_matches = self.autocomp.suggest("a", facets=facets_full)
+        self.assertEqual(partial_matches, full_matches)
+
+    def test_and_group_with_unsupported_key_returns_empty(self):
+        """
+        AND group containing an unsupported key is unsatisfiable — returns empty results
+        """
+        facets = [
+            {
+                "type": "and",
+                "facets": [
+                    {"key": "sector", "value": "Energy"},
+                    {"key": "fake_key", "value": "anything"},
+                ],
+            }
+        ]
+        matches = self.autocomp.suggest("a", facets=facets)
+        self.assertEqual(len(matches), 0)
+
+    def test_or_group_with_all_unsupported_keys_returns_empty(self):
+        """
+        OR group where every key is unsupported is unsatisfiable — returns empty results
+        """
+        facets = [
+            {
+                "type": "or",
+                "facets": [
+                    {"key": "fake_key", "value": "anything"},
+                    {"key": "other_fake", "value": "whatever"},
+                ],
+            }
+        ]
+        matches = self.autocomp.suggest("a", facets=facets)
+        self.assertEqual(len(matches), 0)
+
 
 class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
     fixtures = ["stock_test_data_small.json", "indicator_test_data_small.json"]
@@ -728,5 +783,39 @@ class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
         # the indicator provider supports no facet keys; the AND group is unsatisfiable → empty
         self.assertEqual(len(matches["ind"]), 16)
         self.assertEqual(len(facet_matches["ind"]), 0)
+
+        registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
+
+    def test_mixed_providers_partial_or_facet_applies_to_supporting_provider(self):
+        """
+        OR group with one unsupported key: supporting provider filters by remaining keys;
+        non-supporting provider (no facets) gets empty results (all OR keys unsupported → unsatisfiable)
+        """
+        registry.set_autocompleter_setting(
+            "facet_stock_no_facet_ind", "MAX_RESULTS", 100
+        )
+        facets = [
+            {
+                "type": "or",
+                "facets": [
+                    {"key": "sector", "value": "Financial Services"},
+                    {"key": "fake_key", "value": "anything"},
+                ],
+            }
+        ]
+        facets_sector_only = [
+            {
+                "type": "or",
+                "facets": [{"key": "sector", "value": "Financial Services"}],
+            }
+        ]
+        matches = self.autocomp.suggest("a", facets=facets)
+        matches_sector_only = self.autocomp.suggest("a", facets=facets_sector_only)
+
+        # stock provider: fake_key dropped, sector=Financial Services applied — same as sector-only
+        self.assertEqual(matches["faceted_stock"], matches_sector_only["faceted_stock"])
+
+        # indicator provider: supports no facets → all OR keys unsupported → empty
+        self.assertEqual(len(matches["ind"]), 0)
 
         registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -680,13 +680,11 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         }
         all_facets = facets + [extra_facet]
 
-        regular_matches = self.autocomp.suggest("ch", facets=facets)
+        # both strict and lenient search suggestions will filter results out,
+        # since we ignore `fake_key` facet but still apply `sector` facet in the `extra_facet` group
         matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
-        self.assertEqual(len(matches), 1)
-        self.assertEqual(regular_matches, matches)
-
-        # if we use strict search suggestions, results will be filtered out
         strict_matches = self.autocomp.suggest("ch", facets=all_facets)
+        self.assertEqual(len(matches), 0)
         self.assertEqual(len(strict_matches), 0)
 
         facets = [
@@ -701,14 +699,13 @@ class FacetMatchingTestCase(AutocompleterTestCase):
             "facets": [{"key": "fake_key", "value": "fake value"}, {"key": "sector", "value": "Communication Services"}],
         }
         all_facets = facets + [extra_facet]
-        regular_matches = self.autocomp.suggest("ch", facets=facets)
-        matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
-        self.assertEqual(len(matches), 2)
-        self.assertEqual(regular_matches, matches)
 
-        # if we use strict search suggestions, results will be filtered out
+        # both strict and lenient search suggestions will filter results out,
+        # since we ignore `fake_key` facet but still apply `sector` facet in the `extra_facet` group
+        matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
         strict_matches = self.autocomp.suggest("ch", facets=all_facets)
         self.assertEqual(len(matches), 0)
+        self.assertEqual(len(strict_matches), 0)
 
     def test_or_group_with_partial_keys_applies_supported_only(self):
         """

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -486,9 +486,16 @@ class FacetMatchingTestCase(AutocompleterTestCase):
                 ],
             }
         ]
-        facet_matches = self.autocomp.suggest("a", facets=facets)
-        # AND group with an unsupported key is unsatisfiable — provider returns empty results
-        self.assertEqual(len(facet_matches), 0)
+        regular_matches = self.autocomp.suggest("a")
+        # since the 'thisisfake' key does not exist in our provider, the results for a facet
+        # suggest should be the same as a regular suggest if strict=False
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+        self.assertEqual(facet_matches, regular_matches)
+
+        # if strict=True, the AND group with an unsupported key is unsatisfiable, so provider returns empty results
+        strict_facet_matches = self.autocomp.suggest("a", facets=facets)
+        self.assertEqual(len(strict_facet_matches), 0)
+
 
     def test_provider_keys_is_subset_of_facet_keys_no_match(self):
         """
@@ -710,10 +717,14 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         }
         all_facets = facets + [extra_facet]
 
-        matches = self.autocomp.suggest("ch", facets=all_facets)
-        # OR(fake_key, sector=Energy) drops fake_key, applies sector=Energy; but the AND groups
-        # require sector=Communication Services AND industry=Telecom Services — sector conflict → 0
-        self.assertEqual(len(matches), 0)
+        regular_matches = self.autocomp.suggest("ch", facets=facets)
+        matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(regular_matches, matches)
+
+        # if we use strict search suggestions, results will be filtered out
+        strict_matches = self.autocomp.suggest("ch", facets=all_facets)
+        self.assertEqual(len(strict_matches), 0)
 
         facets = [
             {"type": "and", "facets": [{"key": "sector", "value": "Energy"}]},
@@ -730,9 +741,13 @@ class FacetMatchingTestCase(AutocompleterTestCase):
             ],
         }
         all_facets = facets + [extra_facet]
-        matches = self.autocomp.suggest("ch", facets=all_facets)
-        # OR(fake_key, sector=Communication Services) drops fake_key, applies sector=Communication Services;
-        # but AND groups require sector=Energy — sector conflict → 0
+        regular_matches = self.autocomp.suggest("ch", facets=facets)
+        matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(regular_matches, matches)
+
+        # if we use strict search suggestions, results will be filtered out
+        strict_matches = self.autocomp.suggest("ch", facets=all_facets)
         self.assertEqual(len(matches), 0)
 
     def test_or_group_with_partial_keys_applies_supported_only(self):
@@ -847,16 +862,21 @@ class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
             }
         ]
         matches = self.autocomp.suggest("a")
-        facet_matches = self.autocomp.suggest("a", facets=facets)
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+        strict_facet_matches = self.autocomp.suggest("a", facets=facets)
 
         # because we are using the faceted stock provider in the 'facet_stock_no_facet_ind' AC,
         # we expect using facets will decrease the amount of results when searching.
         self.assertEqual(len(matches["faceted_stock"]), 25)
         self.assertEqual(len(facet_matches["faceted_stock"]), 2)
 
-        # the indicator provider supports no facet keys; the AND group is unsatisfiable → empty
+        # since the indicator provider does not support facets,
+        # we expect the search results from both a facet and non-facet search to be the same if strict=False
         self.assertEqual(len(matches["ind"]), 16)
-        self.assertEqual(len(facet_matches["ind"]), 0)
+        self.assertEqual(len(matches["ind"]), len(facet_matches["ind"]))
+
+        # if we use strict search suggestions, indicators will be filtered out
+        self.assertEqual(len(strict_facet_matches["ind"]), 0)
 
         registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
 

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -790,6 +790,40 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         matches = self.autocomp.suggest("a", facets=facets)
         self.assertEqual(len(matches), 0)
 
+    def test_and_group_with_unsupported_key_lenient_returns_unfiltered(self):
+        """
+        AND facets group with unsupported key is skipped if strict=False, returns unfiltered results
+        """
+        facets = [
+            {
+                "type": "and",
+                "facets": [
+                    {"key": "sector", "value": "Energy"},
+                    {"key": "fake_key", "value": "anything"},
+                ],
+            }
+        ]
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+        regular_matches = self.autocomp.suggest("a")
+        self.assertEqual(facet_matches, regular_matches)
+
+    def test_or_group_with_all_unsupported_keys_lenient_returns_unfiltered(self):
+        """
+        OR group with all unsupported keys is skipped if strict=False, returns unfiltered results
+        """
+        facets = [
+            {
+                "type": "or",
+                "facets": [
+                    {"key": "fake_key", "value": "anything"},
+                    {"key": "other_fake", "value": "whatever"},
+                ],
+            }
+        ]
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+        regular_matches = self.autocomp.suggest("a")
+        self.assertEqual(facet_matches, regular_matches)
+
 
 class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
     fixtures = ["stock_test_data_small.json", "indicator_test_data_small.json"]
@@ -857,6 +891,30 @@ class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
 
         # indicator provider: supports no facets → all OR keys unsupported → empty
         self.assertEqual(len(matches["ind"]), 0)
+
+        registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
+
+    def test_non_facet_provider_lenient_returns_unfiltered(self):
+        """
+        non-facet provider skips unsatisfiable AND group if strict=False, returns unfiltered results
+        """
+        registry.set_autocompleter_setting(
+            "facet_stock_no_facet_ind", "MAX_RESULTS", 100
+        )
+        facets = [
+            {
+                "type": "and",
+                "facets": [{"key": "sector", "value": "Financial Services"}],
+            }
+        ]
+        matches = self.autocomp.suggest("a")
+        facet_matches = self.autocomp.suggest("a", facets=facets, strict=False)
+
+        # stock provider still filters normally
+        self.assertEqual(len(facet_matches["faceted_stock"]), 2)
+
+        # indicator provider: AND group skipped (lenient) → same results as unfiltered
+        self.assertEqual(len(facet_matches["ind"]), len(matches["ind"]))
 
         registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
 

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -487,10 +487,8 @@ class FacetMatchingTestCase(AutocompleterTestCase):
             }
         ]
         facet_matches = self.autocomp.suggest("a", facets=facets)
-        regular_matches = self.autocomp.suggest("a")
-        # since the 'thisisfake' key does not exist in our provider, the results for a facet
-        # suggest should be the same as a regular suggest
-        self.assertEqual(facet_matches, regular_matches)
+        # AND group with an unsupported key is unsatisfiable — provider returns empty results
+        self.assertEqual(len(facet_matches), 0)
 
     def test_provider_keys_is_subset_of_facet_keys_no_match(self):
         """
@@ -712,10 +710,10 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         }
         all_facets = facets + [extra_facet]
 
-        regular_matches = self.autocomp.suggest("ch", facets=facets)
         matches = self.autocomp.suggest("ch", facets=all_facets)
-        self.assertEqual(len(matches), 1)
-        self.assertEqual(regular_matches, matches)
+        # OR(fake_key, sector=Energy) drops fake_key, applies sector=Energy; but the AND groups
+        # require sector=Communication Services AND industry=Telecom Services — sector conflict → 0
+        self.assertEqual(len(matches), 0)
 
         facets = [
             {"type": "and", "facets": [{"key": "sector", "value": "Energy"}]},
@@ -732,10 +730,10 @@ class FacetMatchingTestCase(AutocompleterTestCase):
             ],
         }
         all_facets = facets + [extra_facet]
-        regular_matches = self.autocomp.suggest("ch", facets=facets)
         matches = self.autocomp.suggest("ch", facets=all_facets)
-        self.assertEqual(len(matches), 2)
-        self.assertEqual(regular_matches, matches)
+        # OR(fake_key, sector=Communication Services) drops fake_key, applies sector=Communication Services;
+        # but AND groups require sector=Energy — sector conflict → 0
+        self.assertEqual(len(matches), 0)
 
 
 class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
@@ -767,10 +765,9 @@ class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
         self.assertEqual(len(matches["faceted_stock"]), 25)
         self.assertEqual(len(facet_matches["faceted_stock"]), 2)
 
-        # since the indicator provider does not support facets,
-        # we expect the search results from both a facet and non-facet search to be the same.
+        # the indicator provider supports no facet keys; the AND group is unsatisfiable → empty
         self.assertEqual(len(matches["ind"]), 16)
-        self.assertEqual(len(matches["ind"]), len(facet_matches["ind"]))
+        self.assertEqual(len(facet_matches["ind"]), 0)
 
         registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
 

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -735,6 +735,61 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         # but AND groups require sector=Energy — sector conflict → 0
         self.assertEqual(len(matches), 0)
 
+    def test_or_group_with_partial_keys_applies_supported_only(self):
+        """
+        OR group with one unsupported key drops that key and applies the remaining supported keys
+        """
+        facets_partial = [
+            {
+                "type": "or",
+                "facets": [
+                    {"key": "sector", "value": "Energy"},
+                    {"key": "fake_key", "value": "anything"},
+                ],
+            }
+        ]
+        facets_full = [
+            {
+                "type": "or",
+                "facets": [{"key": "sector", "value": "Energy"}],
+            }
+        ]
+        partial_matches = self.autocomp.suggest("a", facets=facets_partial)
+        full_matches = self.autocomp.suggest("a", facets=facets_full)
+        self.assertEqual(partial_matches, full_matches)
+
+    def test_and_group_with_unsupported_key_returns_empty(self):
+        """
+        AND group containing an unsupported key is unsatisfiable — returns empty results
+        """
+        facets = [
+            {
+                "type": "and",
+                "facets": [
+                    {"key": "sector", "value": "Energy"},
+                    {"key": "fake_key", "value": "anything"},
+                ],
+            }
+        ]
+        matches = self.autocomp.suggest("a", facets=facets)
+        self.assertEqual(len(matches), 0)
+
+    def test_or_group_with_all_unsupported_keys_returns_empty(self):
+        """
+        OR group where every key is unsupported is unsatisfiable — returns empty results
+        """
+        facets = [
+            {
+                "type": "or",
+                "facets": [
+                    {"key": "fake_key", "value": "anything"},
+                    {"key": "other_fake", "value": "whatever"},
+                ],
+            }
+        ]
+        matches = self.autocomp.suggest("a", facets=facets)
+        self.assertEqual(len(matches), 0)
+
 
 class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
     fixtures = ["stock_test_data_small.json", "indicator_test_data_small.json"]
@@ -768,6 +823,40 @@ class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
         # the indicator provider supports no facet keys; the AND group is unsatisfiable → empty
         self.assertEqual(len(matches["ind"]), 16)
         self.assertEqual(len(facet_matches["ind"]), 0)
+
+        registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
+
+    def test_mixed_providers_partial_or_facet_applies_to_supporting_provider(self):
+        """
+        OR group with one unsupported key: supporting provider filters by remaining keys;
+        non-supporting provider (no facets) gets empty results (all OR keys unsupported → unsatisfiable)
+        """
+        registry.set_autocompleter_setting(
+            "facet_stock_no_facet_ind", "MAX_RESULTS", 100
+        )
+        facets = [
+            {
+                "type": "or",
+                "facets": [
+                    {"key": "sector", "value": "Financial Services"},
+                    {"key": "fake_key", "value": "anything"},
+                ],
+            }
+        ]
+        facets_sector_only = [
+            {
+                "type": "or",
+                "facets": [{"key": "sector", "value": "Financial Services"}],
+            }
+        ]
+        matches = self.autocomp.suggest("a", facets=facets)
+        matches_sector_only = self.autocomp.suggest("a", facets=facets_sector_only)
+
+        # stock provider: fake_key dropped, sector=Financial Services applied — same as sector-only
+        self.assertEqual(matches["faceted_stock"], matches_sector_only["faceted_stock"])
+
+        # indicator provider: supports no facets → all OR keys unsupported → empty
+        self.assertEqual(len(matches["ind"]), 0)
 
         registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
 

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -717,13 +717,11 @@ class FacetMatchingTestCase(AutocompleterTestCase):
         }
         all_facets = facets + [extra_facet]
 
-        regular_matches = self.autocomp.suggest("ch", facets=facets)
+        # both strict and lenient search suggestions will filter results out,
+        # since we ignore `fake_key` facet but still apply `sector` facet in the `extra_facet` group
         matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
-        self.assertEqual(len(matches), 1)
-        self.assertEqual(regular_matches, matches)
-
-        # if we use strict search suggestions, results will be filtered out
         strict_matches = self.autocomp.suggest("ch", facets=all_facets)
+        self.assertEqual(len(matches), 0)
         self.assertEqual(len(strict_matches), 0)
 
         facets = [
@@ -741,14 +739,13 @@ class FacetMatchingTestCase(AutocompleterTestCase):
             ],
         }
         all_facets = facets + [extra_facet]
-        regular_matches = self.autocomp.suggest("ch", facets=facets)
-        matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
-        self.assertEqual(len(matches), 2)
-        self.assertEqual(regular_matches, matches)
 
-        # if we use strict search suggestions, results will be filtered out
+        # both strict and lenient search suggestions will filter results out,
+        # since we ignore `fake_key` facet but still apply `sector` facet in the `extra_facet` group
+        matches = self.autocomp.suggest("ch", facets=all_facets, strict=False)
         strict_matches = self.autocomp.suggest("ch", facets=all_facets)
         self.assertEqual(len(matches), 0)
+        self.assertEqual(len(strict_matches), 0)
 
     def test_or_group_with_partial_keys_applies_supported_only(self):
         """


### PR DESCRIPTION
### Overview

When searching with facets in an autocompleter, if a provider doesn't support all facet keys in a group, the entire group is silently skipped — returning **unfiltered** results instead of respecting the filter intent.

This PR fixes the semantics and introduces a `strict` parameter to `suggest()`:

- **AND group with any unsupported key**: can't satisfy all conditions → force **empty results**
- **OR group with all unsupported keys**: no condition can be evaluated → force **empty results**
- **OR group with some unsupported keys**: drop the unsupported ones, apply the rest (an unsupported key contributes ∅ to a union, so dropping it is correct)

| Scenario | `strict=True` (new default) | `strict=False` |
|---|---|---|
| `AND(sector=Energy, fake_key=X)` | empty results | group skipped (unfiltered) |
| `OR(sector=Energy, fake_key=X)` | applies `OR(sector=Energy)` | applies `OR(sector=Energy)` |
| `OR(fake_key=X, other_fake=Y)` | empty results | group skipped (unfiltered) |

> [!Note]
> `strict=True` is a breaking change for multi-provider autocompleters where some providers intentionally declare no facets (e.g. filtering stocks+indicators by `sector` will now return zero indicators). Pass `strict=False` to restore the previous behavior.

### How to test
Use [this guide](https://docs.google.com/document/d/1UKHgWrEtwZkLDoV2pl6zDQo5uJvRB7jzIoKMbKaGdlU/) so you can test this change using it in the `ycharts` app repo. Then, set up the test environment in `yc_shell_plus` with the following code snippet:
<details>
<summary>Click to expand setup code snippet</summary>

```python
from autocompleter import Autocompleter, AutocompleterDictProvider, registry

# ---------------------------------------------------------------------------
# Providers
# ---------------------------------------------------------------------------

STOCKS = [
    {'id': 1, 'phrase': 'apple', 'name': 'Apple Inc.', 'sector': 'Technology'},
    {'id': 2, 'phrase': 'exxon', 'name': 'Axxon Mobil', 'sector': 'Energy'},
    {'id': 3, 'phrase': 'jpmorgan', 'name': 'APMorgan Chase', 'sector': 'Financial Services'},
    {'id': 4, 'phrase': 'chevron', 'name': 'Aevron Corp.', 'sector': 'Energy'},
    {'id': 5, 'phrase': 'amazon', 'name': 'Amazon', 'sector': 'Technology'},
]

INDICATORS = [
    {'id': 101, 'phrase': 'gdp', 'name': 'ADP Growth Rate'},
    {'id': 102, 'phrase': 'inflation', 'name': 'A Inflation Rate'},
    {'id': 103, 'phrase': 'unemployment', 'name': 'A Unemployment Rate'},
]


class FacetedStockProvider(AutocompleterDictProvider):
    provider_name = 'stock'

    @classmethod
    def get_item_dict(cls):
        return {str(s['id']): s for s in STOCKS}

    @classmethod
    def get_facets(cls):
        return ['sector']

    @classmethod
    def get_phrase(cls, item):
        return item['phrase']

    @classmethod
    def get_iterator(cls):
        return STOCKS

    def get_data(self):
        return {'id': self.obj['id'], 'name': self.obj['name'], 'sector': self.obj['sector']}

    def get_item_id(self):
        return self.obj['id']

    def get_term(self):
        return self.obj['name']


class IndicatorProvider(AutocompleterDictProvider):
    """No facets — simulates a provider that doesn't track any facet dimension."""

    provider_name = 'indicator'

    @classmethod
    def get_item_dict(cls):
        return {str(i['id']): i for i in INDICATORS}

    @classmethod
    def get_phrase(cls, item):
        return item['phrase']

    @classmethod
    def get_iterator(cls):
        return INDICATORS

    def get_data(self):
        return {'id': self.obj['id'], 'name': self.obj['name']}

    def get_item_id(self):
        return self.obj['id']

    def get_term(self):
        return self.obj['name']


# ---------------------------------------------------------------------------
# Registration
# ---------------------------------------------------------------------------

AC_NAME = 'test_facets'
registry.register(AC_NAME, FacetedStockProvider)
registry.register(AC_NAME, IndicatorProvider)

ac = Autocompleter(AC_NAME)
ac.store_all()

# ---------------------------------------------------------------------------
# Helpers
# ---------------------------------------------------------------------------


def check(label, result, expected_stock_count, expected_ind_count):
    stock = result.get('stock', [])
    ind = result.get('indicator', [])
    ok_s = len(stock) == expected_stock_count
    ok_i = len(ind) == expected_ind_count
    status = 'PASS' if (ok_s and ok_i) else 'FAIL'
    print(f'\n[{status}] {label}')
    if not ok_s:
        print(f'       stock:     expected {expected_stock_count}, got {len(stock)}')
    if not ok_i:
        print(f'       indicator: expected {expected_ind_count}, got {len(ind)}')
```
</details>

Then, test the following:
- [ ] **Mixed providers — non-facet provider behavior with strict=True**
  <details>
  <summary>Click to expand test code snippet</summary>

  ```python
  # Baseline — no facets
  no_facet = ac.suggest('a')
  total_stocks = len(no_facet.get('stock', []))  # should be 5 (all match "a")
  total_inds = len(no_facet.get('indicator', []))  # should be 3 (all match "a")
  print(f'\nBaseline: {total_stocks} stocks, {total_inds} indicators\n')
  ```
  </details>
- [ ] **AND group — all keys supported (unchanged behavior)**
  <details>
  <summary>Click to expand test code snippet</summary>

  ```python
  # 1. AND — all keys supported (normal filtering)
  r = ac.suggest('a', facets=[{'type': 'and', 'facets': [{'key': 'sector', 'value': 'Energy'}]}])
  check('1. AND(sector=Energy) — filters stock, inds unfiltered [lenient default pre-PR]', r, 2, total_inds)
  ```
  </details>
- [ ] **AND group — unsupported key, strict=True (default)**
  <details>
  <summary>Click to expand test code snippet</summary>

  ```python
  # 2. AND + unsupported key, strict=True → empty for both providers
  r = ac.suggest(
      'a',
      facets=[
          {
              'type': 'and',
              'facets': [
                  {'key': 'sector', 'value': 'Energy'},
                  {'key': 'fake_key', 'value': 'x'},
              ],
          }
      ],
  )
  check('2. AND(sector=Energy, fake_key=x) strict=True → empty for both', r, 0, 0)
  ```
  </details>
- [ ] **AND group — unsupported key, strict=False**
  <details>
  <summary>Click to expand test code snippet</summary>

  ```python
  # 3. AND + unsupported key, strict=False → stock filtered normally, inds unfiltered (group skipped)
  r = ac.suggest(
      'a',
      facets=[
          {
              'type': 'and',
              'facets': [
                  {'key': 'sector', 'value': 'Energy'},
                  {'key': 'fake_key', 'value': 'x'},
              ],
          }
      ],
      strict=False,
  )
  check('3. AND(sector=Energy, fake_key=x) strict=False → stock unfiltered, inds unfiltered', r, total_stocks, total_inds)
  ```
  </details>
- [ ] **OR group — partial unsupported key (same for both strict modes)**
  <details>
  <summary>Click to expand test code snippet</summary>

  ```python
  # 4. OR + partial unsupported key — same result for both strict modes (key is always dropped)
  r_strict = ac.suggest(
      'a',
      facets=[
          {
              'type': 'or',
              'facets': [
                  {'key': 'sector', 'value': 'Energy'},
                  {'key': 'fake_key', 'value': 'x'},
              ],
          }
      ],
  )
  r_lenient = ac.suggest(
      'a',
      facets=[
          {
              'type': 'or',
              'facets': [
                  {'key': 'sector', 'value': 'Energy'},
                  {'key': 'fake_key', 'value': 'x'},
              ],
          }
      ],
      strict=False,
  )
  r_sector_only = ac.suggest('a', facets=[{'type': 'or', 'facets': [{'key': 'sector', 'value': 'Energy'}]}])
  # Stock: fake_key dropped → OR(sector=Energy) → 2 results; Indicator: all OR keys unsupported → empty (strict) / unfiltered
  (lenient)
  check('4a. OR(sector=Energy, fake_key=x) strict=True  → stock=OR(sector), ind=empty', r_strict, 2, 0)
  check('4b. OR(sector=Energy, fake_key=x) strict=False → stock=OR(sector), ind=unfiltered', r_lenient, 2, total_inds)
  print(f'    4c. strict and sector-only results match for stock: {r_strict.get("stock") == r_sector_only.get("stock")}')
  ```
  </details>
- [ ] **OR group — all unsupported keys, strict=True (default)**
  <details>
  <summary>Click to expand test code snippet</summary>

  ```python
  # 5. OR + all unsupported keys, strict=True → empty for both
  r = ac.suggest(
      'a',
      facets=[
          {
              'type': 'or',
              'facets': [
                  {'key': 'fake_key', 'value': 'x'},
                  {'key': 'other_fake', 'value': 'y'},
              ],
          }
      ],
  )
  check('5. OR(fake_key, other_fake) strict=True  → empty for both', r, 0, 0)
  ```
  </details>
- [ ] **OR group — all unsupported keys, strict=False**
  <details>
  <summary>Click to expand test code snippet</summary>

  ```python
  # 6. OR + all unsupported keys, strict=False → unfiltered for both
  r = ac.suggest(
      'a',
      facets=[
          {
              'type': 'or',
              'facets': [
                  {'key': 'fake_key', 'value': 'x'},
                  {'key': 'other_fake', 'value': 'y'},
              ],
          }
      ],
      strict=False,
  )
  check('6. OR(fake_key, other_fake) strict=False → unfiltered for both', r, total_stocks, total_inds)
  ```
  </details>

After you finish your tests, make sure you clean the test data with:
```python
ac.remove_all()
registry.unregister(AC_NAME, FacetedStockProvider)
registry.unregister(AC_NAME, IndicatorProvider)
```