### PR TITLE
add regex filter option to autocompleter settings

### DIFF
--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import logging
+import re
 import uuid
 from collections import OrderedDict
 from hashlib import sha1
@@ -740,6 +741,13 @@ class Autocompleter(AutocompleterBase):
                 self.name, provider, "MIN_LETTERS"
             )
             if len(term) < MIN_LETTERS:
+                continue
+
+            # If the term doesn't match TERM_REGEX, don't search the provider for this term
+            TERM_REGEX = registry.get_ac_provider_setting(
+                self.name, provider, "TERM_REGEX"
+            )
+            if TERM_REGEX is not None and not re.match(TERM_REGEX, term):
                 continue
 
             term_result_keys = []

--- a/autocompleter/settings.py
+++ b/autocompleter/settings.py
@@ -55,3 +55,6 @@ MAX_EXACT_MATCH_WORDS = getattr(settings, "AUTOCOMPLETER_MAX_EXACT_MATCH_WORDS",
 
 # Minimum number of letters required to start returning results
 MIN_LETTERS = getattr(settings, "AUTOCOMPLETER_MIN_LETTERS", 1)
+
+# Regex search term must match to return results
+TERM_REGEX = getattr(settings, "TERM_REGEX", None)


### PR DESCRIPTION
### Overview
Add an autocompleter settings option to prevent searching for results if the search term doesn't match the specified regex.

### How to test
- [ ] TBD

