### PR TITLE
Fix: Mismatch keys between update and suggest/store

### DIFF
--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 1, 8)
+VERSION = (1, 1, 9)
 
 
 from autocompleter.registry import registry, signal_registry

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -331,7 +331,11 @@ class AutocompleterProviderBase(AutocompleterBase):
         data = self.get_data()
         for facet in self.get_facets():
             try:
-                facet_dicts.append({"key": facet, "value": data[facet]})
+                # normalize collections into lists
+                value = data[facet]
+                if isinstance(value, tuple):
+                    value = list(value)
+                facet_dicts.append({"key": facet, "value": value})
             except KeyError:
                 pass
         return facet_dicts

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1412,14 +1412,22 @@ class Autocompleter(AutocompleterBase):
                 if obj_id in objs_with_updated_scores
                 else live_obj_facets - db_obj_facets
             )
-            for key, value in facets_to_add:
-                facet_sorted_set_key = FACET_SET_BASE_NAME % (provider_name, key, value)
-                pipe.zadd(facet_sorted_set_key, {obj_id: scores_live_map[obj_id]})
+            for facet in facets_live_map.get(obj_id, []):
+                hashable_facet = (facet["key"], cls._hashable_value(facet["value"]))
+                if hashable_facet in facets_to_add:
+                    facet_sorted_set_key = FACET_SET_BASE_NAME % (
+                        provider_name, facet["key"], facet["value"]
+                    )
+                    pipe.zadd(facet_sorted_set_key, {obj_id: scores_live_map[obj_id]})
             self.log.info(f"Added {len(facets_to_add)} entries to {FACET_BASE_NAME}")
             facets_to_remove = db_obj_facets - live_obj_facets
-            for key, value in facets_to_remove:
-                facet_sorted_set_key = FACET_SET_BASE_NAME % (provider_name, key, value)
-                pipe.zrem(facet_sorted_set_key, obj_id)
+            for facet in facets_db_map.get(obj_id, []):
+                hashable_facet = (facet["key"], cls._hashable_value(facet["value"]))
+                if hashable_facet in facets_to_remove:
+                    facet_sorted_set_key = FACET_SET_BASE_NAME % (
+                        provider_name, facet["key"], facet["value"]
+                    )
+                    pipe.zrem(facet_sorted_set_key, obj_id)
             self.log.info(
                 f"Removed {len(facets_to_remove)} entries to {FACET_SET_BASE_NAME}"
             )

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1416,22 +1416,23 @@ class Autocompleter(AutocompleterBase):
                 if obj_id in objs_with_updated_scores
                 else live_obj_facets - db_obj_facets
             )
-            for facet in facets_live_map.get(obj_id, []):
-                hashable_facet = (facet["key"], cls._hashable_value(facet["value"]))
-                if hashable_facet in facets_to_add:
-                    facet_sorted_set_key = FACET_SET_BASE_NAME % (
-                        provider_name, facet["key"], facet["value"]
-                    )
-                    pipe.zadd(facet_sorted_set_key, {obj_id: scores_live_map[obj_id]})
+            for key, value in facets_to_add:
+                # `get_facets_dict` normalizes all sequence values to lists,
+                # and `_hashable_value` converts list to tuples for frozenset storage;
+                # so any tuple here was a list originally
+                value = list(value) if isinstance(value, tuple) else value
+                facet_sorted_set_key = FACET_SET_BASE_NAME % (provider_name, key, value)
+                pipe.zadd(facet_sorted_set_key, {obj_id: scores_live_map[obj_id]})
             self.log.info(f"Added {len(facets_to_add)} entries to {FACET_BASE_NAME}")
+
             facets_to_remove = db_obj_facets - live_obj_facets
-            for facet in facets_db_map.get(obj_id, []):
-                hashable_facet = (facet["key"], cls._hashable_value(facet["value"]))
-                if hashable_facet in facets_to_remove:
-                    facet_sorted_set_key = FACET_SET_BASE_NAME % (
-                        provider_name, facet["key"], facet["value"]
-                    )
-                    pipe.zrem(facet_sorted_set_key, obj_id)
+            for key, value in facets_to_remove:
+                # `get_facets_dict` normalizes all sequence values to lists,
+                # and `_hashable_value` converts list to tuples for frozenset storage;
+                # so any tuple here was a list originally
+                value = list(value) if isinstance(value, tuple) else value
+                facet_sorted_set_key = FACET_SET_BASE_NAME % (provider_name, key, value)
+                pipe.zrem(facet_sorted_set_key, obj_id)
             self.log.info(
                 f"Removed {len(facets_to_remove)} entries to {FACET_SET_BASE_NAME}"
             )

--- a/test_project/test_app/autocompleters.py
+++ b/test_project/test_app/autocompleters.py
@@ -241,6 +241,30 @@ class ListFacetedCalcProvider(AutocompleterDictProvider):
         }
 
 
+class TupleFacetedCalcProvider(AutocompleterDictProvider):
+    obj_dict = calc_info.calc_dicts
+    provider_name = "tf_metric"
+
+    def get_item_id(self):
+        return self.obj["short_label"]
+
+    def get_term(self):
+        return self.obj["label"]
+
+    @classmethod
+    def get_facets(cls):
+        return ["categories"]
+
+    def get_data(self):
+        return {
+            "id": self.get_item_id(),
+            "score": 1,
+            "display_name": self.obj["label"],
+            "search_name": self.obj["short_label"],
+            "categories": ("finance", "metric"),
+        }
+
+
 registry.register("faceted_stock", FacetedStockAutocompleteProvider)
 registry.register("stock", StockAutocompleteProvider)
 registry.register("mixed", StockAutocompleteProvider)
@@ -259,3 +283,4 @@ registry.register("facet_stock_no_facet_ind", FacetedStockAutocompleteProvider)
 registry.register("facet_stock_no_facet_ind", IndicatorAutocompleteProvider)
 
 registry.register("list_faceted_metric", ListFacetedCalcProvider)
+registry.register("tuple_faceted_metric", TupleFacetedCalcProvider)

--- a/test_project/test_app/autocompleters.py
+++ b/test_project/test_app/autocompleters.py
@@ -217,6 +217,30 @@ class CalcAliasedAutocompleteProvider(AutocompleterDictProvider):
         return calc_info.calc_dicts
 
 
+class ListFacetedCalcProvider(AutocompleterDictProvider):
+    obj_dict = calc_info.calc_dicts
+    provider_name = "lf_metric"
+
+    def get_item_id(self):
+        return self.obj["short_label"]
+
+    def get_term(self):
+        return self.obj["label"]
+
+    @classmethod
+    def get_facets(cls):
+        return ["categories"]
+
+    def get_data(self):
+        return {
+            "id": self.get_item_id(),
+            "score": 1,
+            "display_name": self.obj["label"],
+            "search_name": self.obj["short_label"],
+            "categories": ["finance", "metric"],
+        }
+
+
 registry.register("faceted_stock", FacetedStockAutocompleteProvider)
 registry.register("stock", StockAutocompleteProvider)
 registry.register("mixed", StockAutocompleteProvider)
@@ -233,3 +257,5 @@ registry.register("metric_aliased", CalcAliasedAutocompleteProvider)
 
 registry.register("facet_stock_no_facet_ind", FacetedStockAutocompleteProvider)
 registry.register("facet_stock_no_facet_ind", IndicatorAutocompleteProvider)
+
+registry.register("list_faceted_metric", ListFacetedCalcProvider)

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -739,7 +739,7 @@ class ListFacetUpdateProviderTestCase(AutocompleterTestCase):
     def setUp(self):
         super().setUp()
         self.autocomp = Autocompleter("list_faceted_metric")
-        self.store_all_for_ac("list_faceted_metric")
+        self.autocomp.store_all()
 
     def test_update_provider_writes_list_repr_facet_keys(self):
         """
@@ -751,8 +751,8 @@ class ListFacetUpdateProviderTestCase(AutocompleterTestCase):
         matches_after_store = self.autocomp.suggest("rev", facets=facets)
         self.assertGreater(len(matches_after_store), 0)
 
-        self.remove_all_for_ac("list_faceted_metric")
-        self.update_all_for_ac("list_faceted_metric")
+        self.autocomp.remove_all()
+        self.autocomp.update_all()
 
         matches_after_update = self.autocomp.suggest("rev", facets=facets)
         self.assertEqual(matches_after_store, matches_after_update)
@@ -762,7 +762,7 @@ class TupleFacetUpdateTestCase(AutocompleterTestCase):
     def setUp(self):
         super().setUp()
         self.autocomp = Autocompleter("tuple_faceted_metric")
-        self.store_all_for_ac("tuple_faceted_metric")
+        self.autocomp.store_all()
 
     def test_tuple_facet_value_normalized_to_list(self):
         """
@@ -782,8 +782,8 @@ class TupleFacetUpdateTestCase(AutocompleterTestCase):
         """
         facets = [{"type": "or", "facets": [{"key": "categories", "value": ["finance", "metric"]}]}]
 
-        self.remove_all_for_ac("tuple_faceted_metric")
-        self.update_all_for_ac("tuple_faceted_metric")
+        self.autocomp.remove_all()
+        self.autocomp.update_all()
 
         matches = self.autocomp.suggest("rev", facets=facets)
         self.assertGreater(len(matches), 0)

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -758,7 +758,7 @@ class ListFacetUpdateProviderTestCase(AutocompleterTestCase):
         self.assertEqual(matches_after_store, matches_after_update)
 
 
-class TupleFacetNormalizationTestCase(AutocompleterTestCase):
+class TupleFacetUpdateTestCase(AutocompleterTestCase):
     def setUp(self):
         super().setUp()
         self.autocomp = Autocompleter("tuple_faceted_metric")
@@ -770,6 +770,20 @@ class TupleFacetNormalizationTestCase(AutocompleterTestCase):
         suggest() callers don't need to know the original type from get_data().
         """
         facets = [{"type": "or", "facets": [{"key": "categories", "value": ["finance", "metric"]}]}]
+
+        matches = self.autocomp.suggest("rev", facets=facets)
+        self.assertGreater(len(matches), 0)
+
+    def test_update_provider_with_tuple_facet_value(self):
+        """
+        update_provider must produce the same list-repr facet keys as store() even when
+        get_data() returns tuple values, relying on get_facets_dict() normalization
+        and the tuple→list reversal in the update_provider loops.
+        """
+        facets = [{"type": "or", "facets": [{"key": "categories", "value": ["finance", "metric"]}]}]
+
+        self.remove_all_for_ac("tuple_faceted_metric")
+        self.update_all_for_ac("tuple_faceted_metric")
 
         matches = self.autocomp.suggest("rev", facets=facets)
         self.assertGreater(len(matches), 0)

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -756,3 +756,20 @@ class ListFacetUpdateProviderTestCase(AutocompleterTestCase):
 
         matches_after_update = self.autocomp.suggest("rev", facets=facets)
         self.assertEqual(matches_after_store, matches_after_update)
+
+
+class TupleFacetNormalizationTestCase(AutocompleterTestCase):
+    def setUp(self):
+        super().setUp()
+        self.autocomp = Autocompleter("tuple_faceted_metric")
+        self.store_all_for_ac("tuple_faceted_metric")
+
+    def test_tuple_facet_value_normalized_to_list(self):
+        """
+        get_facets_dict() must convert tuple facet values to lists so that
+        suggest() callers don't need to know the original type from get_data().
+        """
+        facets = [{"type": "or", "facets": [{"key": "categories", "value": ["finance", "metric"]}]}]
+
+        matches = self.autocomp.suggest("rev", facets=facets)
+        self.assertGreater(len(matches), 0)

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -733,3 +733,26 @@ class MixedFacetProvidersMatchingTestCase(AutocompleterTestCase):
         self.assertEqual(len(matches["ind"]), len(facet_matches["ind"]))
 
         registry.del_autocompleter_setting("facet_stock_no_facet_ind", "MAX_RESULTS")
+
+
+class ListFacetUpdateProviderTestCase(AutocompleterTestCase):
+    def setUp(self):
+        super().setUp()
+        self.autocomp = Autocompleter("list_faceted_metric")
+        self.store_all_for_ac("list_faceted_metric")
+
+    def test_update_provider_writes_list_repr_facet_keys(self):
+        """
+        update_provider must write the same facet key format as store() so that
+        suggest() can find the results after a bulk update.
+        """
+        facets = [{"type": "or", "facets": [{"key": "categories", "value": ["finance", "metric"]}]}]
+
+        matches_after_store = self.autocomp.suggest("rev", facets=facets)
+        self.assertGreater(len(matches_after_store), 0)
+
+        self.remove_all_for_ac("list_faceted_metric")
+        self.update_all_for_ac("list_faceted_metric")
+
+        matches_after_update = self.autocomp.suggest("rev", facets=facets)
+        self.assertEqual(matches_after_store, matches_after_update)


### PR DESCRIPTION
### Overview
When facet values are lists (e.g. `['dataUCITS']`), the bulk update path (`update_provider`) was writing them to Redis using keys with a tuple instead (e.g. `('dataUCITS',)`). Since the search path (`suggest`) expects the keys to have the list value, the keys never matched, so filtering by those facets silently returned no results after a bulk update.

The fix has two parts:
1. We made `update_provider` reconstruct the Redis key from the original value rather than a hashable copy it had made internally for set-comparison purposes.
2. As a defensive measure, we normalized all facet values to lists at the point they're built (`get_facets_dict`), since the database serialization layer already does this implicitly — making lists the single canonical type across all code paths.

### How to test
- [x] Test must pass.
- [x] Follow [this guide](https://docs.google.com/document/d/1UKHgWrEtwZkLDoV2pl6zDQo5uJvRB7jzIoKMbKaGdlU/), so you can test this change using it in the `ycharts` app repo.
- [x] Paste the following to create a shared base for manual testing in `yc_shell_plus`:
  ```python
  from pprint import pformat

  from autocompleter import AutocompleterDictProvider, Autocompleter, registry

  # Define a minimal base provider
  class DebugProvider(AutocompleterDictProvider):
      obj_dict = [
          {"label": "Revenue TTM", "short_label": "TURTTM"},
          {"label": "Market Cap",  "short_label": "MCAP"},
      ]
      provider_name = "list_metric"

      def get_item_id(self):
          return self.obj["short_label"]

      def get_term(self):
          return self.obj["label"]

      @classmethod
      def get_facets(cls):
          return ["categories"]

  # A function to automatically test the behavior
  def test_suggestions(provider_class):
      registry.register("dbg_metric", provider_class)
      ac = Autocompleter("dbg_metric")
      facets = [{"type": "or", "facets": [{"key": "categories", "value": ["finance", "metric"]}]}]

      # 1. Suggest after store()
      ac.store_all()

      after_store = ac.suggest("rev", facets=facets)
      print(f"After store(): {pformat(after_store)}")

      # 2. Suggest after update_provider()
      ac.remove_all()
      ac.update_all()

      after_update = ac.suggest("rev", facets=facets)
      print(f"After update_provider(): {pformat(after_update)}")

      print("Match and not empty:", bool(after_store and after_store == after_update))

      # Cleanup
      ac.remove_all()
      registry.unregister("dbg_metric", provider_class)
  ```
- [x] Validate the issue is fixed for list facets:
  ```python
  # Define a provider with a list-valued facet
  class ListProvider(DebugProvider):
      def get_data(self):
          return {
              "id": self.get_item_id(),
              "score": 1,
              "display_name": self.obj["label"],
              "search_name": self.obj["short_label"],
              "categories": ["finance", "metric"],
          }

  test_suggestions(ListProvider)
  ```
- [x] Validate the issue is fixed for tuples facets:
  ```python
  # Define a provider with a tuple-valued facet
  class TupleProvider(DebugProvider):
      def get_data(self):
          return {
              "id": self.get_item_id(),
              "score": 1,
              "display_name": self.obj["label"],
              "search_name": self.obj["short_label"],
              "categories": ("finance", "metric"),
          }

  test_suggestions(TupleProvider)
  ```
