### PR TITLE
Fix join char dupe term

### DIFF
--- a/autocompleter/registry.py
+++ b/autocompleter/registry.py
@@ -162,7 +162,7 @@ class AutocompleterRegistry(object):
         # Provider specific version
         try:
             provider_settings = getattr(provider, "settings")
-            setting_value = provider_settings["setting_name"]
+            setting_value = provider_settings[setting_name]
             return setting_value
         except (KeyError, AttributeError):
             # Global version

--- a/autocompleter/utils.py
+++ b/autocompleter/utils.py
@@ -62,7 +62,7 @@ def get_norm_term_variations(term):
             # So that every combination of replace x with '', y with '', x with ' ' y with '' etc is created.
             norm_term = replace_all(norm_term, replace=present_join_chars, with_this="")
             norm_term = norm_term.strip()
-            if norm_term != "" and norm_term not in norm_terms:
+            if norm_term != "":
                 norm_terms.add(norm_term)
     else:
         norm_term = get_normalized_term(term, []).strip()

--- a/autocompleter/utils.py
+++ b/autocompleter/utils.py
@@ -44,11 +44,11 @@ def get_norm_term_variations(term):
     """
     Get variations of a term in normalized form
     """
-    norm_terms = []
+    norm_terms = set()
     # create list of what join chars we care about that are in the term
     present_join_chars = [i for i in settings.JOIN_CHARS if i in term]
     # If none are present, we can just normalize without replacing anything, otherwise...
-    if present_join_chars != []:
+    if present_join_chars:
         join_char_combinations = [
             "".join(subset)
             for n in range(len(present_join_chars) + 1)
@@ -61,12 +61,13 @@ def get_norm_term_variations(term):
             # Now get rid of ALL present join characters and replace with empty string
             # So that every combination of replace x with '', y with '', x with ' ' y with '' etc is created.
             norm_term = replace_all(norm_term, replace=present_join_chars, with_this="")
-            if norm_term not in norm_terms and norm_term.strip() != "":
-                norm_terms.append(norm_term)
+            norm_term = norm_term.strip()
+            if norm_term != "" and norm_term not in norm_terms:
+                norm_terms.add(norm_term)
     else:
-        norm_term = get_normalized_term(term, [])
-        if norm_term.strip() != "":
-            norm_terms.append(norm_term)
+        norm_term = get_normalized_term(term, []).strip()
+        if norm_term != "":
+            norm_terms.add(norm_term)
     return norm_terms
 
 

--- a/autocompleter/utils.py
+++ b/autocompleter/utils.py
@@ -68,7 +68,7 @@ def get_norm_term_variations(term):
         norm_term = get_normalized_term(term, []).strip()
         if norm_term != "":
             norm_terms.add(norm_term)
-    return norm_terms
+    return sorted(norm_terms)
 
 
 def get_aliased_variations(term, phrase_aliases):

--- a/test_project/test_app/tests/test_utils.py
+++ b/test_project/test_app/tests/test_utils.py
@@ -252,8 +252,7 @@ class TestNormalizedTerm(TestCase):
 class TestNormTermVariations(TestCase):
     def test_join_char_does_not_produce_dupe(self):
         """
-        A trailing join char like "p/" must not produce two variations "p" and "p "
-        instead of just one "p"
+        A trailing join char in a string, e.g. "p/", should just return "p" as opposed to "p" and "p "
         """
         variations = get_norm_term_variations("p/")
         self.assertEqual(variations, {"p"})

--- a/test_project/test_app/tests/test_utils.py
+++ b/test_project/test_app/tests/test_utils.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from autocompleter import Autocompleter
-from autocompleter.utils import get_normalized_term
+from autocompleter.utils import get_norm_term_variations, get_normalized_term
 from autocompleter.views import SuggestView
 
 
@@ -247,3 +247,15 @@ class TestNormalizedTerm(TestCase):
             " cent change",
             get_normalized_term("Non Percent Change", replaced_chars=["non", "per"]),
         )
+
+
+class TestNormTermVariations(TestCase):
+    def test_special_char_does_not_product_dupe(self):
+        """
+        A trailing join char like "p/" must not produce two "p" variants.
+        Without stripping, the join-char-as-space branch yields "p " while
+        the strip branch yields "p"; both reduce to the prefix word "p"
+        and cause duplicate prefix keys to be passed to ZUNIONSTORE.
+        """
+        variations = get_norm_term_variations("p/")
+        self.assertEqual(variations, {"p"})

--- a/test_project/test_app/tests/test_utils.py
+++ b/test_project/test_app/tests/test_utils.py
@@ -250,12 +250,10 @@ class TestNormalizedTerm(TestCase):
 
 
 class TestNormTermVariations(TestCase):
-    def test_special_char_does_not_product_dupe(self):
+    def test_join_char_does_not_produce_dupe(self):
         """
-        A trailing join char like "p/" must not produce two "p" variants.
-        Without stripping, the join-char-as-space branch yields "p " while
-        the strip branch yields "p"; both reduce to the prefix word "p"
-        and cause duplicate prefix keys to be passed to ZUNIONSTORE.
+        A trailing join char like "p/" must not produce two variations "p" and "p "
+        instead of just one "p"
         """
         variations = get_norm_term_variations("p/")
         self.assertEqual(variations, {"p"})

--- a/test_project/test_app/tests/test_utils.py
+++ b/test_project/test_app/tests/test_utils.py
@@ -255,4 +255,4 @@ class TestNormTermVariations(TestCase):
         A trailing join char in a string, e.g. "p/", should just return "p" as opposed to "p" and "p "
         """
         variations = get_norm_term_variations("p/")
-        self.assertEqual(variations, {"p"})
+        self.assertEqual(variations, ["p"])


### PR DESCRIPTION
### Overview
Looking through the [redis slowlog on datadag](https://app.datadoghq.com/logs?query=env%3Aproduction%20service%3Avalkey_autocompleter_slowlog_monitor&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40execution_duration_ms&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=%40execution_duration_ms%2Cdesc&viz=stream&from_ts=1777570928678&to_ts=1778175728678&live=true), noticed a strange operation happening:
 `ZUNIONSTORE djac.results.869e56fe-6967-4f5d-a110-f5037d54762c 2 djac.mp.p.p djac.mp.p.p`

Looks like we are taking the union of the same portfolio set which makes no sense. Fix that in the `get_norm_term_variations` method.

### How to test
- [x] check the added test case `test_join_char_does_not_produce_dupe` makes sense 
