### PR TITLE
Add cardinality threshold setting

### DIFF
--- a/autocompleter/__init__.py
+++ b/autocompleter/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 3, 0)
+VERSION = (1, 4, 0)
 
 
 from django.utils.module_loading import autodiscover_modules

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1527,6 +1527,9 @@ class Autocompleter(AutocompleterBase):
 
     @staticmethod
     def _get_prefix_key_to_cardinality_mapping(providers, norm_terms):
+        """
+        For each provider and normalized term, get the cardinality of the corresponding prefix sorted sets
+        """
         all_prefix_key_names = []
         for provider in providers:
             provider_name = provider.provider_name

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1057,6 +1057,13 @@ class Autocompleter(AutocompleterBase):
         # Get the max results autocompleter setting
         MAX_RESULTS = registry.get_autocompleter_setting(self.name, "MAX_RESULTS")
 
+        prefix_key_to_cardinality = self._get_prefix_key_to_cardinality_mapping(providers, norm_terms)
+        high_cardinality_keys = {
+            key
+            for key, card in prefix_key_to_cardinality.items()
+            if card > settings.CARDINALITY_THRESHOLD
+        }
+
         pipe = REDIS.pipeline(transaction=False)
         for provider in providers:
             provider_name = provider.provider_name
@@ -1070,6 +1077,7 @@ class Autocompleter(AutocompleterBase):
                 continue
 
             term_result_keys = []
+            high_cardinality_key_detected_for_provider = False
             for norm_term in norm_terms:
                 norm_words = norm_term.split()
                 keys = [
@@ -1080,19 +1088,38 @@ class Autocompleter(AutocompleterBase):
                     )
                     for norm_word in norm_words
                 ]
+                high_cardinality_key_detected_for_term = False
+                if any(k in high_cardinality_keys for k in keys):
+                    high_cardinality_key_detected_for_term = True
+                    high_cardinality_key_detected_for_provider = True
                 if len(keys) == 1:
                     term_result_keys.append(keys[0])
                 else:
-                    term_result_key = base_result_key + "." + norm_term
-                    term_result_keys.append(term_result_key)
-                    keys_to_delete.add(term_result_key)
-                    pipe.zinterstore(term_result_key, keys, aggregate="MIN")
+                    if high_cardinality_key_detected_for_term:
+                        # at least one set exceeds the cardinality threshold, skip the intersection, use the
+                        # smallest of these keys as a proxy for the intersection
+                        smallest_key = min(keys, key=lambda k: prefix_key_to_cardinality[k])
+                        term_result_keys.append(smallest_key)
+                    else:
+                        term_result_key = base_result_key + "." + norm_term
+                        term_result_keys.append(term_result_key)
+                        keys_to_delete.add(term_result_key)
+                        pipe.zinterstore(term_result_key, keys, aggregate="MIN")
 
             if len(term_result_keys) == 1:
                 final_result_key = term_result_keys[0]
             else:
-                final_result_key = base_result_key
-                pipe.zunionstore(final_result_key, term_result_keys, aggregate="MIN")
+                # the only way a term result key could be large here would be if a norm word only led to a single prefix
+                # key which was large, because it would have bypassed the above smallest key logic
+                # in this situation, we don't actually know the smallest key because we don't have cardinalities
+                # of the term result keys, only the prefix keys. So we fall back to either picking the smallest prefix
+                # key, or randomly picking one of the term result keys.
+                if high_cardinality_key_detected_for_provider:
+                    smallest_key = min(term_result_keys, key=lambda k: prefix_key_to_cardinality.get(k, 0))
+                    final_result_key = smallest_key
+                else:
+                    final_result_key = base_result_key
+                    pipe.zunionstore(final_result_key, term_result_keys, aggregate="MIN")
 
             provider_keys_set = set(provider.get_facets())
 
@@ -1497,3 +1524,27 @@ class Autocompleter(AutocompleterBase):
             return int((round(value) + (abs(value) / value) * 1))
         else:
             return int(round(value))
+
+    @staticmethod
+    def _get_prefix_key_to_cardinality_mapping(providers, norm_terms):
+        all_prefix_key_names = []
+        for provider in providers:
+            provider_name = provider.provider_name
+
+            for norm_term in norm_terms:
+                norm_words = norm_term.split()
+                prefix_key_set_names = [
+                    PREFIX_BASE_NAME
+                    % (
+                        provider_name,
+                        norm_word,
+                    )
+                    for norm_word in norm_words
+                ]
+                all_prefix_key_names.extend(prefix_key_set_names)
+
+        pipe = REDIS.pipeline(transaction=False)
+        for prefix_key_name in all_prefix_key_names:
+            pipe.zcard(prefix_key_name)
+        prefix_key_to_cardinality = dict(zip(all_prefix_key_names, pipe.execute()))
+        return prefix_key_to_cardinality

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -1057,12 +1057,7 @@ class Autocompleter(AutocompleterBase):
         # Get the max results autocompleter setting
         MAX_RESULTS = registry.get_autocompleter_setting(self.name, "MAX_RESULTS")
 
-        prefix_key_to_cardinality = self._get_prefix_key_to_cardinality_mapping(providers, norm_terms)
-        high_cardinality_keys = {
-            key
-            for key, card in prefix_key_to_cardinality.items()
-            if card > settings.CARDINALITY_THRESHOLD
-        }
+        keys_to_cardinality = self._get_prefix_key_to_cardinality_mapping(providers, norm_terms)
 
         pipe = REDIS.pipeline(transaction=False)
         for provider in providers:
@@ -1077,7 +1072,6 @@ class Autocompleter(AutocompleterBase):
                 continue
 
             term_result_keys = []
-            high_cardinality_key_detected_for_provider = False
             for norm_term in norm_terms:
                 norm_words = norm_term.split()
                 keys = [
@@ -1088,34 +1082,31 @@ class Autocompleter(AutocompleterBase):
                     )
                     for norm_word in norm_words
                 ]
-                high_cardinality_key_detected_for_term = False
-                if any(k in high_cardinality_keys for k in keys):
-                    high_cardinality_key_detected_for_term = True
-                    high_cardinality_key_detected_for_provider = True
                 if len(keys) == 1:
                     term_result_keys.append(keys[0])
                 else:
-                    if high_cardinality_key_detected_for_term:
-                        # at least one set exceeds the cardinality threshold, skip the intersection, use the
+                    smallest_key = min(keys, key=lambda k: keys_to_cardinality[k])
+                    smallest_key_cardinality = keys_to_cardinality[smallest_key]
+                    if smallest_key_cardinality > settings.CARDINALITY_THRESHOLD_INTERSECTION:
+                        # the smallest key in this operation exceeds the threshold, skip the intersection, use the
                         # smallest of these keys as a proxy for the intersection
-                        smallest_key = min(keys, key=lambda k: prefix_key_to_cardinality[k])
                         term_result_keys.append(smallest_key)
                     else:
                         term_result_key = base_result_key + "." + norm_term
                         term_result_keys.append(term_result_key)
                         keys_to_delete.add(term_result_key)
+                        # we don't know exactly what the term result key cardinality will be,
+                        # but it cannot be larger than the smallest key's cardinality when doing an intersection
+                        # so we set it as such to help future union optimizations
+                        keys_to_cardinality[term_result_key] = smallest_key_cardinality
                         pipe.zinterstore(term_result_key, keys, aggregate="MIN")
 
             if len(term_result_keys) == 1:
                 final_result_key = term_result_keys[0]
             else:
-                # the only way a term result key could be large here would be if a norm word only led to a single prefix
-                # key which was large, because it would have bypassed the above smallest key logic
-                # in this situation, we don't actually know the smallest key because we don't have cardinalities
-                # of the term result keys, only the prefix keys. So we fall back to either picking the smallest prefix
-                # key, or randomly picking one of the term result keys.
-                if high_cardinality_key_detected_for_provider:
-                    smallest_key = min(term_result_keys, key=lambda k: prefix_key_to_cardinality.get(k, 0))
+                cardinality_sum = sum(keys_to_cardinality.get(k, 0) for k in term_result_keys)
+                if cardinality_sum > settings.CARDINALITY_THRESHOLD_UNION:
+                    smallest_key = min(term_result_keys, key=lambda k: keys_to_cardinality.get(k, 0))
                     final_result_key = smallest_key
                 else:
                     final_result_key = base_result_key

--- a/autocompleter/settings.py
+++ b/autocompleter/settings.py
@@ -18,14 +18,6 @@ FLATTEN_SINGLE_TYPE_RESULTS = getattr(
     settings, "AUTOCOMPLETER_FLATTEN_SINGLE_TYPE_RESULTS", True
 )
 
-# Maximum number of items that a particular prefix set can contain before we stop doing expensive operations on it
-# (intersections and unions). In this scenario, the autocompleter will just use the min cardinality set from the given
-# prefix sets that the autocompleter is attempting to compute the expensive calculation on.
-# For example, if you have a prefix set with 50,000 items and a prefix set with 10 items, the autocompleter will just
-# use the prefix set with 10 items and ignore the prefix set with 50,000 items instead of trying to compute
-# an intersection/union of the two sets, which could be prohibitively expensive.
-CARDINALITY_THRESHOLD = getattr(settings, "AUTOCOMPLETER_CARDINALITY_THRESHOLD", 50_000)
-
 # Characters we want the autocompleter to interpret as both a space and a blank string.
 # Meaning by default, 'U/S-A' will also be stored as 'U SA', 'US A', 'U S A', and 'USA'
 JOIN_CHARS = getattr(settings, "AUTOCOMPLETER_JOIN_CHARS", ["-", "/"])
@@ -39,6 +31,17 @@ SUGGEST_PARAMETER_NAME = getattr(settings, "AUTOCOMPLETER_SUGGEST_PARAMETER_NAME
 # Test data for debugging/running tests
 TEST_DATA = getattr(settings, "AUTOCOMPLETER_TEST_DATA", False)
 
+## Advanced optimization settings
+
+# When handling a suggest call that involves a multi-word term that could lead to large result sizes,
+# if the smallest set involved exceeds this threshold, skip the intersection operation
+# and use that smallest set as a proxy for the intersection.
+CARDINALITY_THRESHOLD_INTERSECTION = getattr( settings, "AUTOCOMPLETER_CARDINALITY_THRESHOLD_INTERSECTION", 50_000)
+
+# When combining result sets across normalized term variations, if the combined number of
+# members across all sets exceeds this threshold, skip the union and use the smallest
+# set as a proxy for the union.
+CARDINALITY_THRESHOLD_UNION = getattr(settings, "AUTOCOMPLETER_CARDINALITY_THRESHOLD_UNION", 50_000)
 
 # AC SETTINGS #
 

--- a/autocompleter/settings.py
+++ b/autocompleter/settings.py
@@ -36,7 +36,7 @@ TEST_DATA = getattr(settings, "AUTOCOMPLETER_TEST_DATA", False)
 # When handling a suggest call that involves a multi-word term that could lead to large result sizes,
 # if the smallest set involved exceeds this threshold, skip the intersection operation
 # and use that smallest set as a proxy for the intersection.
-CARDINALITY_THRESHOLD_INTERSECTION = getattr( settings, "AUTOCOMPLETER_CARDINALITY_THRESHOLD_INTERSECTION", 50_000)
+CARDINALITY_THRESHOLD_INTERSECTION = getattr(settings, "AUTOCOMPLETER_CARDINALITY_THRESHOLD_INTERSECTION", 50_000)
 
 # When combining result sets across normalized term variations, if the combined number of
 # members across all sets exceeds this threshold, skip the union and use the smallest

--- a/autocompleter/settings.py
+++ b/autocompleter/settings.py
@@ -18,6 +18,14 @@ FLATTEN_SINGLE_TYPE_RESULTS = getattr(
     settings, "AUTOCOMPLETER_FLATTEN_SINGLE_TYPE_RESULTS", True
 )
 
+# Maximum number of items that a particular prefix set can contain before we stop doing expensive operations on it
+# (intersections and unions). In this scenario, the autocompleter will just use the min cardinality set from the given
+# prefix sets that the autocompleter is attempting to compute the expensive calculation on.
+# For example, if you have a prefix set with 50,000 items and a prefix set with 10 items, the autocompleter will just
+# use the prefix set with 10 items and ignore the prefix set with 50,000 items instead of trying to compute
+# an intersection/union of the two sets, which could be prohibitively expensive.
+CARDINALITY_THRESHOLD = getattr(settings, "AUTOCOMPLETER_CARDINALITY_THRESHOLD", 50_000)
+
 # Characters we want the autocompleter to interpret as both a space and a blank string.
 # Meaning by default, 'U/S-A' will also be stored as 'U SA', 'US A', 'U S A', and 'USA'
 JOIN_CHARS = getattr(settings, "AUTOCOMPLETER_JOIN_CHARS", ["-", "/"])

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -988,3 +988,114 @@ class TupleFacetUpdateTestCase(AutocompleterTestCase):
 
         matches = self.autocomp.suggest("rev", facets=facets)
         self.assertGreater(len(matches), 0)
+
+
+class CardinalityThresholdMatchingTestCase(AutocompleterTestCase):
+    """
+    Tests for the CARDINALITY_THRESHOLD setting. When a per-word prefix set exceeds the
+    threshold, suggest() skips the expensive zinterstore/zunionstore and uses the smallest
+    involved prefix set as a proxy.
+
+    We rely on the indicator fixture, where "treasury rate" is a clean example: the word
+    "treasury" matches "Treasury Deposits" while the intersection with "rate" does not.
+    """
+
+    fixtures = ["indicator_test_data_small.json"]
+
+    def setUp(self):
+        super().setUp()
+        self.autocomp = Autocompleter("indicator")
+        self.store_all_for_ac("indicator")
+
+    def tearDown(self):
+        self.remove_all_for_ac("indicator")
+        # The setting persists on the module, so always restore it to the default even if an
+        # assertion failed mid-test.
+        setattr(auto_settings, "CARDINALITY_THRESHOLD", 50_000)
+
+    @staticmethod
+    def _display_names(matches):
+        return {match["display_name"] for match in matches}
+
+    def test_default_threshold_computes_intersection(self):
+        """
+        With the default (high) threshold, a multi-word query returns the true intersection of
+        its per-word prefix sets, so items matching only one of the words are excluded.
+        """
+        names = self._display_names(self.autocomp.suggest("treasury rate"))
+
+        self.assertGreater(len(names), 0)
+        for name in names:
+            self.assertIn("treasury", name.lower())
+            self.assertIn("rate", name.lower())
+        # "Treasury Deposits" matches "treasury" but not "rate", so the intersection excludes it.
+        self.assertNotIn("Treasury Deposits", names)
+
+    def test_threshold_exceeded_skips_intersection(self):
+        """
+        A threshold of 0 forces every non-empty prefix set to be treated as high-cardinality,
+        so the intersection is skipped in favor of the smallest prefix set ("treasury"). The
+        result is a superset of the true intersection.
+        """
+        intersection_names = self._display_names(self.autocomp.suggest("treasury rate"))
+
+        setattr(auto_settings, "CARDINALITY_THRESHOLD", 0)
+        proxy_names = self._display_names(self.autocomp.suggest("treasury rate"))
+
+        # The proxy result (the "treasury" prefix set) is a superset of the intersection...
+        self.assertTrue(intersection_names.issubset(proxy_names))
+        # ...and now includes an item that only matches the smaller word.
+        self.assertIn("Treasury Deposits", proxy_names)
+        self.assertNotIn("Treasury Deposits", intersection_names)
+
+    def test_threshold_comparison_is_strict(self):
+        """
+        The threshold check is strict (card > threshold). A prefix set whose size equals the
+        threshold is NOT treated as high-cardinality, so the intersection is still computed;
+        dropping the threshold one below the largest set flips that.
+        """
+        providers = self.autocomp._get_all_providers_by_autocompleter()
+        cardinalities = Autocompleter._get_prefix_key_to_cardinality_mapping(
+            providers, ["treasury rate"]
+        )
+        max_card = max(cardinalities.values())
+
+        # threshold == largest involved set -> not exceeded -> intersection computed.
+        setattr(auto_settings, "CARDINALITY_THRESHOLD", max_card)
+        names = self._display_names(self.autocomp.suggest("treasury rate"))
+        self.assertNotIn("Treasury Deposits", names)
+
+        # threshold one below the largest involved set -> exceeded -> intersection skipped.
+        setattr(auto_settings, "CARDINALITY_THRESHOLD", max_card - 1)
+        names = self._display_names(self.autocomp.suggest("treasury rate"))
+        self.assertIn("Treasury Deposits", names)
+
+    def test_prefix_key_to_cardinality_mapping(self):
+        """
+        _get_prefix_key_to_cardinality_mapping returns one entry per (provider, normalized word)
+        prefix key, mapped to that set's actual Redis cardinality.
+        """
+        providers = self.autocomp._get_all_providers_by_autocompleter()
+        cardinalities = Autocompleter._get_prefix_key_to_cardinality_mapping(
+            providers, ["treasury"]
+        )
+
+        # Single provider, single word -> a single prefix key.
+        self.assertEqual(len(cardinalities), 1)
+        key, card = next(iter(cardinalities.items()))
+        self.assertTrue(key.endswith("ind.p.treasury"))
+        self.assertGreater(card, 0)
+        self.assertEqual(card, self.redis.zcard(key))
+
+    def test_threshold_exceeded_union_path_still_returns_results(self):
+        """
+        Join-char queries ("mortgage-backed") produce multiple normalized terms and exercise the
+        union code path. When the threshold is exceeded the union is skipped for a single proxy
+        key, but the known matching item should still be returned.
+        """
+        names = self._display_names(self.autocomp.suggest("mortgage-backed"))
+        self.assertTrue(any("Mortgage-Backed Securities" in name for name in names))
+
+        setattr(auto_settings, "CARDINALITY_THRESHOLD", 0)
+        proxy_names = self._display_names(self.autocomp.suggest("mortgage-backed"))
+        self.assertTrue(any("Mortgage-Backed Securities" in name for name in proxy_names))

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -1070,23 +1070,6 @@ class CardinalityThresholdMatchingTestCase(AutocompleterTestCase):
         names = self._display_names(self.autocomp.suggest("treasury rate"))
         self.assertIn("Treasury Deposits", names)
 
-    def test_prefix_key_to_cardinality_mapping(self):
-        """
-        _get_prefix_key_to_cardinality_mapping returns one entry per (provider, normalized word)
-        prefix key, mapped to that set's actual Redis cardinality.
-        """
-        providers = self.autocomp._get_all_providers_by_autocompleter()
-        cardinalities = Autocompleter._get_prefix_key_to_cardinality_mapping(
-            providers, ["treasury"]
-        )
-
-        # Single provider, single word -> a single prefix key.
-        self.assertEqual(len(cardinalities), 1)
-        key, card = next(iter(cardinalities.items()))
-        self.assertTrue(key.endswith("ind.p.treasury"))
-        self.assertGreater(card, 0)
-        self.assertEqual(card, self.redis.zcard(key))
-
     def test_threshold_exceeded_union_path_still_returns_results(self):
         """
         Join-char queries ("mortgage-backed") produce multiple normalized terms and exercise the

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -992,15 +992,25 @@ class TupleFacetUpdateTestCase(AutocompleterTestCase):
 
 class CardinalityThresholdMatchingTestCase(AutocompleterTestCase):
     """
-    Tests for the CARDINALITY_THRESHOLD setting. When a per-word prefix set exceeds the
-    threshold, suggest() skips the expensive zinterstore/zunionstore and uses the smallest
-    involved prefix set as a proxy.
+    Tests for the CARDINALITY_THRESHOLD_INTERSECTION / CARDINALITY_THRESHOLD_UNION settings.
+
+    When the cost of a set operation is projected to exceed its threshold, suggest() skips the
+    expensive zinterstore/zunionstore and falls back to the smallest involved set as a proxy.
+    The cost models match Redis' worst case:
+      * ZINTERSTORE is bounded by the *smallest* input set, so the intersection skip is driven
+        by the smallest per-word prefix set's cardinality.
+      * ZUNIONSTORE is bounded by the *sum* of input sets, so the union skip is driven by the
+        sum of the term-result-key cardinalities.
 
     We rely on the indicator fixture, where "treasury rate" is a clean example: the word
-    "treasury" matches "Treasury Deposits" while the intersection with "rate" does not.
+    "treasury" matches "Treasury Deposits" while the intersection with "rate" does not. The
+    "treasury" set is small while the "rate" set is large, which lets us prove the intersection
+    decision keys off the smaller set.
     """
 
     fixtures = ["indicator_test_data_small.json"]
+
+    DEFAULT_THRESHOLD = 50_000
 
     def setUp(self):
         super().setUp()
@@ -1009,17 +1019,22 @@ class CardinalityThresholdMatchingTestCase(AutocompleterTestCase):
 
     def tearDown(self):
         self.remove_all_for_ac("indicator")
-        # The setting persists on the module, so always restore it to the default even if an
-        # assertion failed mid-test.
-        setattr(auto_settings, "CARDINALITY_THRESHOLD", 50_000)
+        # The settings persist on the module, so always restore them to their defaults even if
+        # an assertion failed mid-test.
+        setattr(auto_settings, "CARDINALITY_THRESHOLD_INTERSECTION", self.DEFAULT_THRESHOLD)
+        setattr(auto_settings, "CARDINALITY_THRESHOLD_UNION", self.DEFAULT_THRESHOLD)
 
     @staticmethod
     def _display_names(matches):
         return {match["display_name"] for match in matches}
 
-    def test_default_threshold_computes_intersection(self):
+    def _prefix_cardinalities(self, norm_terms):
+        providers = self.autocomp._get_all_providers_by_autocompleter()
+        return Autocompleter._get_prefix_key_to_cardinality_mapping(providers, norm_terms)
+
+    def test_default_thresholds_compute_intersection(self):
         """
-        With the default (high) threshold, a multi-word query returns the true intersection of
+        With the default (high) thresholds, a multi-word query returns the true intersection of
         its per-word prefix sets, so items matching only one of the words are excluded.
         """
         names = self._display_names(self.autocomp.suggest("treasury rate"))
@@ -1031,15 +1046,15 @@ class CardinalityThresholdMatchingTestCase(AutocompleterTestCase):
         # "Treasury Deposits" matches "treasury" but not "rate", so the intersection excludes it.
         self.assertNotIn("Treasury Deposits", names)
 
-    def test_threshold_exceeded_skips_intersection(self):
+    def test_intersection_threshold_zero_skips_intersection(self):
         """
-        A threshold of 0 forces every non-empty prefix set to be treated as high-cardinality,
-        so the intersection is skipped in favor of the smallest prefix set ("treasury"). The
-        result is a superset of the true intersection.
+        An intersection threshold of 0 forces every non-empty set over the limit, so the
+        intersection is skipped in favor of the smallest prefix set ("treasury"). The result is
+        a superset of the true intersection.
         """
         intersection_names = self._display_names(self.autocomp.suggest("treasury rate"))
 
-        setattr(auto_settings, "CARDINALITY_THRESHOLD", 0)
+        setattr(auto_settings, "CARDINALITY_THRESHOLD_INTERSECTION", 0)
         proxy_names = self._display_names(self.autocomp.suggest("treasury rate"))
 
         # The proxy result (the "treasury" prefix set) is a superset of the intersection...
@@ -1048,37 +1063,71 @@ class CardinalityThresholdMatchingTestCase(AutocompleterTestCase):
         self.assertIn("Treasury Deposits", proxy_names)
         self.assertNotIn("Treasury Deposits", intersection_names)
 
-    def test_threshold_comparison_is_strict(self):
+    def test_intersection_decision_keys_off_smallest_set(self):
         """
-        The threshold check is strict (card > threshold). A prefix set whose size equals the
-        threshold is NOT treated as high-cardinality, so the intersection is still computed;
-        dropping the threshold one below the largest set flips that.
+        The intersection skip is driven by the *smallest* per-word set, not the largest. Setting
+        the threshold equal to the smallest set's cardinality (which is far below the large
+        "rate" set) must NOT trigger the skip: equality is not over the strict threshold, and
+        the large "rate" set is irrelevant to the decision.
         """
-        providers = self.autocomp._get_all_providers_by_autocompleter()
-        cardinalities = Autocompleter._get_prefix_key_to_cardinality_mapping(
-            providers, ["treasury rate"]
-        )
-        max_card = max(cardinalities.values())
+        cardinalities = self._prefix_cardinalities(["treasury rate"])
+        smallest_card = min(cardinalities.values())
+        largest_card = max(cardinalities.values())
+        # Sanity check the fixture really does give us a small set alongside a much larger one.
+        self.assertLess(smallest_card, largest_card)
 
-        # threshold == largest involved set -> not exceeded -> intersection computed.
-        setattr(auto_settings, "CARDINALITY_THRESHOLD", max_card)
+        # threshold == smallest set -> not strictly exceeded -> intersection still computed,
+        # even though the "rate" set is much larger than the threshold.
+        setattr(auto_settings, "CARDINALITY_THRESHOLD_INTERSECTION", smallest_card)
         names = self._display_names(self.autocomp.suggest("treasury rate"))
         self.assertNotIn("Treasury Deposits", names)
 
-        # threshold one below the largest involved set -> exceeded -> intersection skipped.
-        setattr(auto_settings, "CARDINALITY_THRESHOLD", max_card - 1)
+        # threshold one below the smallest set -> strictly exceeded -> intersection skipped.
+        setattr(auto_settings, "CARDINALITY_THRESHOLD_INTERSECTION", smallest_card - 1)
         names = self._display_names(self.autocomp.suggest("treasury rate"))
         self.assertIn("Treasury Deposits", names)
 
-    def test_threshold_exceeded_union_path_still_returns_results(self):
+    def test_union_threshold_zero_skips_union(self):
         """
-        Join-char queries ("mortgage-backed") produce multiple normalized terms and exercise the
-        union code path. When the threshold is exceeded the union is skipped for a single proxy
-        key, but the known matching item should still be returned.
+        Join-char queries ("U-S/A") expand to several normalized terms and exercise the union
+        path. A union threshold of 0 (with the intersection threshold left high) skips the
+        zunionstore in favor of the single smallest term-result-key, yielding a non-empty subset
+        of the full union.
         """
-        names = self._display_names(self.autocomp.suggest("mortgage-backed"))
-        self.assertTrue(any("Mortgage-Backed Securities" in name for name in names))
+        baseline_names = self._display_names(self.autocomp.suggest("U-S/A"))
+        # The full union spans many "US ..." items, so it is meaningfully larger than one set.
+        self.assertGreater(len(baseline_names), 1)
 
-        setattr(auto_settings, "CARDINALITY_THRESHOLD", 0)
-        proxy_names = self._display_names(self.autocomp.suggest("mortgage-backed"))
-        self.assertTrue(any("Mortgage-Backed Securities" in name for name in proxy_names))
+        setattr(auto_settings, "CARDINALITY_THRESHOLD_UNION", 0)
+        proxy_names = self._display_names(self.autocomp.suggest("U-S/A"))
+
+        self.assertGreater(len(proxy_names), 0)
+        self.assertTrue(proxy_names.issubset(baseline_names))
+        self.assertLess(len(proxy_names), len(baseline_names))
+
+    def test_thresholds_are_independent(self):
+        """
+        The two thresholds govern different operations. A single-word-per-term query like
+        "treasury rate" only ever intersects (it never unions), so collapsing the union
+        threshold to 0 must not change its results.
+        """
+        baseline_names = self._display_names(self.autocomp.suggest("treasury rate"))
+
+        setattr(auto_settings, "CARDINALITY_THRESHOLD_UNION", 0)
+        names = self._display_names(self.autocomp.suggest("treasury rate"))
+        self.assertEqual(names, baseline_names)
+        self.assertNotIn("Treasury Deposits", names)
+
+    def test_prefix_key_to_cardinality_mapping(self):
+        """
+        _get_prefix_key_to_cardinality_mapping returns one entry per (provider, normalized word)
+        prefix key, mapped to that set's actual Redis cardinality.
+        """
+        cardinalities = self._prefix_cardinalities(["treasury"])
+
+        # Single provider, single word -> a single prefix key.
+        self.assertEqual(len(cardinalities), 1)
+        key, card = next(iter(cardinalities.items()))
+        self.assertTrue(key.endswith("ind.p.treasury"))
+        self.assertGreater(card, 0)
+        self.assertEqual(card, self.redis.zcard(key))

--- a/test_project/test_app/tests/test_matching.py
+++ b/test_project/test_app/tests/test_matching.py
@@ -1117,17 +1117,3 @@ class CardinalityThresholdMatchingTestCase(AutocompleterTestCase):
         names = self._display_names(self.autocomp.suggest("treasury rate"))
         self.assertEqual(names, baseline_names)
         self.assertNotIn("Treasury Deposits", names)
-
-    def test_prefix_key_to_cardinality_mapping(self):
-        """
-        _get_prefix_key_to_cardinality_mapping returns one entry per (provider, normalized word)
-        prefix key, mapped to that set's actual Redis cardinality.
-        """
-        cardinalities = self._prefix_cardinalities(["treasury"])
-
-        # Single provider, single word -> a single prefix key.
-        self.assertEqual(len(cardinalities), 1)
-        key, card = next(iter(cardinalities.items()))
-        self.assertTrue(key.endswith("ind.p.treasury"))
-        self.assertGreater(card, 0)
-        self.assertEqual(card, self.redis.zcard(key))


### PR DESCRIPTION
### Overview
https://app.asana.com/1/1144271657183267/project/1203633948717779/task/1215562168531283?focus=true

Add a cardinality threshold that short circuits expensive operations (ZINTERSTORE, ZUNIONSTORE) when dealing with very large prefix sets.

### How to test
- [ ] test suite passes
